### PR TITLE
Liz instrument position training

### DIFF
--- a/VirtualTools/Assets/Prefabs/InstrumentPositioningTaskSlot.prefab
+++ b/VirtualTools/Assets/Prefabs/InstrumentPositioningTaskSlot.prefab
@@ -60,7 +60,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: e4942f02d8ecc984093e0081b20253f9, type: 2}
+  - {fileID: 0}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -92,7 +92,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 1, y: 1, z: 1}
+  m_Size: {x: 1.87, y: 5.95, z: 1.94}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!114 &459082684401764533
 MonoBehaviour:

--- a/VirtualTools/Assets/Prefabs/InstrumentPositioningTaskSlot.prefab
+++ b/VirtualTools/Assets/Prefabs/InstrumentPositioningTaskSlot.prefab
@@ -1,0 +1,110 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4842086219158482387
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8845084480710435644}
+  - component: {fileID: 480484717406674109}
+  - component: {fileID: 9211614581758705517}
+  - component: {fileID: 8597043365387931012}
+  - component: {fileID: 459082684401764533}
+  m_Layer: 8
+  m_Name: InstrumentPositioningTaskSlot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8845084480710435644
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4842086219158482387}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: -0.066, z: 0}
+  m_LocalScale: {x: 0.11897, y: 0.0014094185, z: 0.11897}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &480484717406674109
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4842086219158482387}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &9211614581758705517
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4842086219158482387}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e4942f02d8ecc984093e0081b20253f9, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!65 &8597043365387931012
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4842086219158482387}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &459082684401764533
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4842086219158482387}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c916de4b1ab2b35448142b8876742f05, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CurrentInstrument: 8
+  CorrectInstrument: 8

--- a/VirtualTools/Assets/Prefabs/InstrumentPositioningTaskSlot.prefab.meta
+++ b/VirtualTools/Assets/Prefabs/InstrumentPositioningTaskSlot.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 19ea898947e66c24cbd20d3d356c8026
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VirtualTools/Assets/Prefabs/Instruments/New/Addson-Brown Forceps.prefab
+++ b/VirtualTools/Assets/Prefabs/Instruments/New/Addson-Brown Forceps.prefab
@@ -10,7 +10,6 @@ GameObject:
   m_Component:
   - component: {fileID: 7824032710535489772}
   - component: {fileID: 6618420923820622770}
-  - component: {fileID: 9140152480470255503}
   - component: {fileID: 6543683611350522617}
   - component: {fileID: 6543683611350522616}
   m_Layer: 8
@@ -27,13 +26,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6543683611350522623}
-  m_LocalRotation: {x: -0.5, y: 0.5, z: 0.5, w: 0.5}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 1.646, y: 1.0577, z: -1.3}
-  m_LocalScale: {x: 0.02, y: 0.02, z: 0.02}
-  m_Children: []
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2538524016670589765}
   m_Father: {fileID: 0}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: -90, y: 90, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &6618420923820622770
 MeshFilter:
   m_ObjectHideFlags: 0
@@ -42,45 +42,6 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6543683611350522623}
   m_Mesh: {fileID: 8681237571545070976, guid: 4560edd1d38bc23438ab92d7f7a05fde, type: 3}
---- !u!23 &9140152480470255503
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6543683611350522623}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 3c01c93bb7012694da54c0101a0bbb80, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
 --- !u!65 &6543683611350522617
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -92,7 +53,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 11.95, y: 5.51, z: 2.39}
+  m_Size: {x: 0.1, y: 0.1, z: 0.25}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!114 &6543683611350522616
 MonoBehaviour:
@@ -109,3 +70,95 @@ MonoBehaviour:
   originalPosition: {x: 0, y: 0, z: 0}
   originalRotation: {x: 0, y: 0, z: 0, w: 0}
   instrumentTag: 0
+--- !u!1001 &8861364244918185543
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 7824032710535489772}
+    m_Modifications:
+    - target: {fileID: 6468090388820323586, guid: 0ef3a3191c639544ebb01f37c868a8f8,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6468090388820323586, guid: 0ef3a3191c639544ebb01f37c868a8f8,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6468090388820323586, guid: 0ef3a3191c639544ebb01f37c868a8f8,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6468090388820323586, guid: 0ef3a3191c639544ebb01f37c868a8f8,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6468090388820323586, guid: 0ef3a3191c639544ebb01f37c868a8f8,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6468090388820323586, guid: 0ef3a3191c639544ebb01f37c868a8f8,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6468090388820323586, guid: 0ef3a3191c639544ebb01f37c868a8f8,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6468090388820323586, guid: 0ef3a3191c639544ebb01f37c868a8f8,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6468090388820323586, guid: 0ef3a3191c639544ebb01f37c868a8f8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: 6468090388820323586, guid: 0ef3a3191c639544ebb01f37c868a8f8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 6468090388820323586, guid: 0ef3a3191c639544ebb01f37c868a8f8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6468090388820323586, guid: 0ef3a3191c639544ebb01f37c868a8f8,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.02
+      objectReference: {fileID: 0}
+    - target: {fileID: 6468090388820323586, guid: 0ef3a3191c639544ebb01f37c868a8f8,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.02
+      objectReference: {fileID: 0}
+    - target: {fileID: 6468090388820323586, guid: 0ef3a3191c639544ebb01f37c868a8f8,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.02
+      objectReference: {fileID: 0}
+    - target: {fileID: 8041208095467511569, guid: 0ef3a3191c639544ebb01f37c868a8f8,
+        type: 3}
+      propertyPath: m_Name
+      value: Addson-Brown Forceps
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 8041208095467511575, guid: 0ef3a3191c639544ebb01f37c868a8f8, type: 3}
+    - {fileID: 8041208095467511574, guid: 0ef3a3191c639544ebb01f37c868a8f8, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: 0ef3a3191c639544ebb01f37c868a8f8, type: 3}
+--- !u!4 &2538524016670589765 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6468090388820323586, guid: 0ef3a3191c639544ebb01f37c868a8f8,
+    type: 3}
+  m_PrefabInstance: {fileID: 8861364244918185543}
+  m_PrefabAsset: {fileID: 0}

--- a/VirtualTools/Assets/Prefabs/Instruments/New/Mayo Hegar Needle Driver.prefab
+++ b/VirtualTools/Assets/Prefabs/Instruments/New/Mayo Hegar Needle Driver.prefab
@@ -9,6 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3454874516449610472}
+  - component: {fileID: 1885773633}
   m_Layer: 0
   m_Name: Mayo Hegar Needle Driver
   m_TagString: Untagged
@@ -31,6 +32,21 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1885773633
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3454874515643799202}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 106d62bf4e5fc984cb592d2156187a46, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  originalPosition: {x: 0, y: 0, z: 0}
+  originalRotation: {x: 0, y: 0, z: 0, w: 0}
+  instrumentTag: 4
 --- !u!1 &6055164023144445991
 GameObject:
   m_ObjectHideFlags: 0
@@ -43,7 +59,6 @@ GameObject:
   - component: {fileID: 6055164023144445987}
   - component: {fileID: 6055164023144445984}
   - component: {fileID: 6055164023144445990}
-  - component: {fileID: 6055164023144445985}
   m_Layer: 8
   m_Name: Mayo Hegar Needle Driver
   m_TagString: Untagged
@@ -59,7 +74,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6055164023144445991}
   m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
-  m_LocalPosition: {x: 2.655, y: 1.051, z: -1.374}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1.9266198, y: 66.36533, z: 2.46063}
   m_Children: []
   m_Father: {fileID: 3454874516449610472}
@@ -126,18 +141,3 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 0.15, y: 0.004, z: 0.03}
   m_Center: {x: 0, y: 0, z: 0}
---- !u!114 &6055164023144445985
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6055164023144445991}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 106d62bf4e5fc984cb592d2156187a46, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  originalPosition: {x: 0, y: 0, z: 0}
-  originalRotation: {x: 0, y: 0, z: 0, w: 0}
-  instrumentTag: 4

--- a/VirtualTools/Assets/Prefabs/Instruments/New/Mayo Hegar Needle Driver.prefab
+++ b/VirtualTools/Assets/Prefabs/Instruments/New/Mayo Hegar Needle Driver.prefab
@@ -9,8 +9,9 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3454874516449610472}
-  - component: {fileID: 1885773633}
-  m_Layer: 0
+  - component: {fileID: 753899801}
+  - component: {fileID: 753899802}
+  m_Layer: 8
   m_Name: Mayo Hegar Needle Driver
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -32,7 +33,20 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1885773633
+--- !u!65 &753899801
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3454874515643799202}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.16, y: 0.1, z: 0.23}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &753899802
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -58,8 +72,7 @@ GameObject:
   - component: {fileID: 6055164021811127405}
   - component: {fileID: 6055164023144445987}
   - component: {fileID: 6055164023144445984}
-  - component: {fileID: 6055164023144445990}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: Mayo Hegar Needle Driver
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -128,16 +141,3 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
---- !u!65 &6055164023144445990
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6055164023144445991}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 0.15, y: 0.004, z: 0.03}
-  m_Center: {x: 0, y: 0, z: 0}

--- a/VirtualTools/Assets/Prefabs/Instruments/New/Mayo Hegar Needle Driver.prefab
+++ b/VirtualTools/Assets/Prefabs/Instruments/New/Mayo Hegar Needle Driver.prefab
@@ -9,11 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3454874516449610472}
-  - component: {fileID: 3454874515643799206}
-  - component: {fileID: 3454874515643799205}
-  - component: {fileID: 3454874515643799203}
-  - component: {fileID: 3454874515643799204}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: Mayo Hegar Needle Driver
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -27,28 +23,63 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3454874515643799202}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 2.6610732, y: 1.0517892, z: -1.3629756}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 6055164021811127405}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6055164023144445991
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6055164021811127405}
+  - component: {fileID: 6055164023144445987}
+  - component: {fileID: 6055164023144445984}
+  - component: {fileID: 6055164023144445990}
+  - component: {fileID: 6055164023144445985}
+  m_Layer: 8
+  m_Name: Mayo Hegar Needle Driver
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6055164021811127405
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6055164023144445991}
   m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 2.655, y: 1.051, z: -1.374}
   m_LocalScale: {x: 1.9266198, y: 66.36533, z: 2.46063}
   m_Children: []
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 3454874516449610472}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
---- !u!33 &3454874515643799206
+--- !u!33 &6055164023144445987
 MeshFilter:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3454874515643799202}
+  m_GameObject: {fileID: 6055164023144445991}
   m_Mesh: {fileID: 587366007896238738, guid: 0b3cb49b5194ca742aeefc8aa8274fe1, type: 3}
---- !u!23 &3454874515643799205
+--- !u!23 &6055164023144445984
 MeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3454874515643799202}
+  m_GameObject: {fileID: 6055164023144445991}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -82,26 +113,26 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
---- !u!65 &3454874515643799203
+--- !u!65 &6055164023144445990
 BoxCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3454874515643799202}
+  m_GameObject: {fileID: 6055164023144445991}
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
   m_Size: {x: 0.15, y: 0.004, z: 0.03}
   m_Center: {x: 0, y: 0, z: 0}
---- !u!114 &3454874515643799204
+--- !u!114 &6055164023144445985
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3454874515643799202}
+  m_GameObject: {fileID: 6055164023144445991}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 106d62bf4e5fc984cb592d2156187a46, type: 3}

--- a/VirtualTools/Assets/Prefabs/Instruments/New/Rochester Carmalt Forceps.prefab
+++ b/VirtualTools/Assets/Prefabs/Instruments/New/Rochester Carmalt Forceps.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &9201191353581874717
+--- !u!1 &2496998817826050426
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,11 +8,11 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 5326187233620941838}
-  - component: {fileID: 3796936558263494200}
-  - component: {fileID: 7461871694684527297}
-  - component: {fileID: 905469674935534972}
-  - component: {fileID: 905469674935534915}
+  - component: {fileID: 1512161541875655529}
+  - component: {fileID: 7613124433410939231}
+  - component: {fileID: 4223190340502660518}
+  - component: {fileID: 5874649017309788699}
+  - component: {fileID: 5874649017309788708}
   m_Layer: 8
   m_Name: Rochester Carmalt Forceps
   m_TagString: Untagged
@@ -20,35 +20,35 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &5326187233620941838
+--- !u!4 &1512161541875655529
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9201191353581874717}
+  m_GameObject: {fileID: 2496998817826050426}
   m_LocalRotation: {x: 0, y: 0.7071068, z: 0.7071068, w: 0}
   m_LocalPosition: {x: 0.5, y: 1.0469, z: -1.3}
   m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
   m_Children: []
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 5326187233620941838}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: -90, y: 180, z: 0}
---- !u!33 &3796936558263494200
+--- !u!33 &7613124433410939231
 MeshFilter:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9201191353581874717}
+  m_GameObject: {fileID: 2496998817826050426}
   m_Mesh: {fileID: 7567522517075773572, guid: d4f71af09710c634980598a23e68e36c, type: 3}
---- !u!23 &7461871694684527297
+--- !u!23 &4223190340502660518
 MeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9201191353581874717}
+  m_GameObject: {fileID: 2496998817826050426}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -81,26 +81,26 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
---- !u!65 &905469674935534972
+--- !u!65 &5874649017309788699
 BoxCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9201191353581874717}
+  m_GameObject: {fileID: 2496998817826050426}
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
   m_Size: {x: 3.86, y: 5.26, z: 1.48}
   m_Center: {x: -0.18833414, y: 0.15834278, z: 0.099891126}
---- !u!114 &905469674935534915
+--- !u!114 &5874649017309788708
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9201191353581874717}
+  m_GameObject: {fileID: 2496998817826050426}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 106d62bf4e5fc984cb592d2156187a46, type: 3}
@@ -109,3 +109,34 @@ MonoBehaviour:
   originalPosition: {x: 0, y: 0, z: 0}
   originalRotation: {x: 0, y: 0, z: 0, w: 0}
   instrumentTag: 3
+--- !u!1 &9201191353581874717
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5326187233620941838}
+  m_Layer: 0
+  m_Name: Rochester Carmalt Forceps
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5326187233620941838
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9201191353581874717}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 5.3160734, y: 2.1027892, z: -2.7369757}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1512161541875655529}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/VirtualTools/Assets/Prefabs/Instruments/New/Rochester Carmalt Forceps.prefab
+++ b/VirtualTools/Assets/Prefabs/Instruments/New/Rochester Carmalt Forceps.prefab
@@ -12,7 +12,6 @@ GameObject:
   - component: {fileID: 7613124433410939231}
   - component: {fileID: 4223190340502660518}
   - component: {fileID: 5874649017309788699}
-  - component: {fileID: 5874649017309788708}
   m_Layer: 8
   m_Name: Rochester Carmalt Forceps
   m_TagString: Untagged
@@ -28,7 +27,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2496998817826050426}
   m_LocalRotation: {x: 0, y: 0.7071068, z: 0.7071068, w: 0}
-  m_LocalPosition: {x: 0.5, y: 1.0469, z: -1.3}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
   m_Children: []
   m_Father: {fileID: 5326187233620941838}
@@ -94,21 +93,6 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 3.86, y: 5.26, z: 1.48}
   m_Center: {x: -0.18833414, y: 0.15834278, z: 0.099891126}
---- !u!114 &5874649017309788708
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2496998817826050426}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 106d62bf4e5fc984cb592d2156187a46, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  originalPosition: {x: 0, y: 0, z: 0}
-  originalRotation: {x: 0, y: 0, z: 0, w: 0}
-  instrumentTag: 3
 --- !u!1 &9201191353581874717
 GameObject:
   m_ObjectHideFlags: 0
@@ -118,6 +102,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5326187233620941838}
+  - component: {fileID: 7583250013219598802}
   m_Layer: 0
   m_Name: Rochester Carmalt Forceps
   m_TagString: Untagged
@@ -140,3 +125,18 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7583250013219598802
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9201191353581874717}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 106d62bf4e5fc984cb592d2156187a46, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  originalPosition: {x: 0, y: 0, z: 0}
+  originalRotation: {x: 0, y: 0, z: 0, w: 0}
+  instrumentTag: 3

--- a/VirtualTools/Assets/Prefabs/Instruments/New/Rochester Carmalt Forceps.prefab
+++ b/VirtualTools/Assets/Prefabs/Instruments/New/Rochester Carmalt Forceps.prefab
@@ -11,8 +11,7 @@ GameObject:
   - component: {fileID: 1512161541875655529}
   - component: {fileID: 7613124433410939231}
   - component: {fileID: 4223190340502660518}
-  - component: {fileID: 5874649017309788699}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: Rochester Carmalt Forceps
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -26,13 +25,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2496998817826050426}
-  m_LocalRotation: {x: 0, y: 0.7071068, z: 0.7071068, w: 0}
+  m_LocalRotation: {x: 0, y: -0.7071068, z: 0.7071068, w: 0}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
   m_Children: []
   m_Father: {fileID: 5326187233620941838}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: -90, y: 180, z: 0}
+  m_LocalEulerAnglesHint: {x: 90, y: -180, z: 0}
 --- !u!33 &7613124433410939231
 MeshFilter:
   m_ObjectHideFlags: 0
@@ -80,19 +79,6 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
---- !u!65 &5874649017309788699
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2496998817826050426}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 3.86, y: 5.26, z: 1.48}
-  m_Center: {x: -0.18833414, y: 0.15834278, z: 0.099891126}
 --- !u!1 &9201191353581874717
 GameObject:
   m_ObjectHideFlags: 0
@@ -102,8 +88,9 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5326187233620941838}
-  - component: {fileID: 7583250013219598802}
-  m_Layer: 0
+  - component: {fileID: 2071385072}
+  - component: {fileID: 2071385071}
+  m_Layer: 8
   m_Name: Rochester Carmalt Forceps
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -125,7 +112,20 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &7583250013219598802
+--- !u!65 &2071385072
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9201191353581874717}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.2, y: 0.1, z: 0.3}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &2071385071
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}

--- a/VirtualTools/Assets/Prefabs/Instruments/New/Suture Scissor.prefab
+++ b/VirtualTools/Assets/Prefabs/Instruments/New/Suture Scissor.prefab
@@ -10,7 +10,6 @@ GameObject:
   m_Component:
   - component: {fileID: 4916199555798148860}
   - component: {fileID: 4916199555801604048}
-  - component: {fileID: 4916199555800385576}
   - component: {fileID: 6283951441460668706}
   - component: {fileID: 4916199555671496144}
   m_Layer: 8
@@ -27,13 +26,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4916199555798427652}
-  m_LocalRotation: {x: -0.5, y: 0.5, z: 0.5, w: 0.5}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 1.093, y: 1.0507, z: -1.289}
   m_LocalScale: {x: 0.03, y: 0.03, z: 0.03}
-  m_Children: []
+  m_Children:
+  - {fileID: 5993535978662539183}
   m_Father: {fileID: 0}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: -90, y: 90, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &4916199555801604048
 MeshFilter:
   m_ObjectHideFlags: 0
@@ -42,45 +42,6 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4916199555798427652}
   m_Mesh: {fileID: -8302102485596996044, guid: 1407ff1a4a965fd47ac9704b9bf692d5, type: 3}
---- !u!23 &4916199555800385576
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4916199555798427652}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 3c01c93bb7012694da54c0101a0bbb80, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
 --- !u!65 &6283951441460668706
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -92,7 +53,7 @@ BoxCollider:
   m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 12.72, y: 4.81, z: 8.11}
+  m_Size: {x: 5.69, y: 4.91, z: 8.11}
   m_Center: {x: -4.440892e-16, y: -0.00000010430813, z: -0.00000011920932}
 --- !u!114 &4916199555671496144
 MonoBehaviour:
@@ -109,3 +70,94 @@ MonoBehaviour:
   originalPosition: {x: 0, y: 0, z: 0}
   originalRotation: {x: 0, y: 0, z: 0, w: 0}
   instrumentTag: 5
+--- !u!1001 &357725764352871690
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 4916199555798148860}
+    m_Modifications:
+    - target: {fileID: 6330852267670006877, guid: b2774ef181440854d88c841149282e1d,
+        type: 3}
+      propertyPath: m_Name
+      value: Suture Scissor
+      objectReference: {fileID: 0}
+    - target: {fileID: 6330852267670250149, guid: b2774ef181440854d88c841149282e1d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6330852267670250149, guid: b2774ef181440854d88c841149282e1d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6330852267670250149, guid: b2774ef181440854d88c841149282e1d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6330852267670250149, guid: b2774ef181440854d88c841149282e1d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6330852267670250149, guid: b2774ef181440854d88c841149282e1d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6330852267670250149, guid: b2774ef181440854d88c841149282e1d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6330852267670250149, guid: b2774ef181440854d88c841149282e1d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6330852267670250149, guid: b2774ef181440854d88c841149282e1d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6330852267670250149, guid: b2774ef181440854d88c841149282e1d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: 6330852267670250149, guid: b2774ef181440854d88c841149282e1d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 6330852267670250149, guid: b2774ef181440854d88c841149282e1d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6330852267670250149, guid: b2774ef181440854d88c841149282e1d,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6330852267670250149, guid: b2774ef181440854d88c841149282e1d,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6330852267670250149, guid: b2774ef181440854d88c841149282e1d,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 4960566969904344443, guid: b2774ef181440854d88c841149282e1d, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: b2774ef181440854d88c841149282e1d, type: 3}
+--- !u!4 &5993535978662539183 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6330852267670250149, guid: b2774ef181440854d88c841149282e1d,
+    type: 3}
+  m_PrefabInstance: {fileID: 357725764352871690}
+  m_PrefabAsset: {fileID: 0}

--- a/VirtualTools/Assets/Scenes/SelectByName.unity
+++ b/VirtualTools/Assets/Scenes/SelectByName.unity
@@ -146,7 +146,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8670678}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -2.671, y: 1.114, z: -1.2799366}
+  m_LocalPosition: {x: -2.671, y: 1.143, z: -1.2799366}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 446510651}
@@ -3706,8 +3706,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 60d13bc78235f4840a771135c8e7bae1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Material: {fileID: 2100000, guid: e4942f02d8ecc984093e0081b20253f9, type: 2}
-  MaterialSelected: {fileID: 2100000, guid: f270d43c0b849ce4f9b0509f3f51f7d4, type: 2}
   InstrumentSlots:
   - {fileID: 1948299625}
   - {fileID: 470690623}

--- a/VirtualTools/Assets/Scenes/SelectByName.unity
+++ b/VirtualTools/Assets/Scenes/SelectByName.unity
@@ -2327,6 +2327,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 9211614581758705517, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: e4942f02d8ecc984093e0081b20253f9, type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 19ea898947e66c24cbd20d3d356c8026, type: 3}
 --- !u!4 &446510651 stripped
@@ -2872,6 +2877,18 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 6543683611350522616, guid: 485d73ee977fbba4e906a193afa05542,
     type: 3}
   m_PrefabInstance: {fileID: 3843762615708644309}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 106d62bf4e5fc984cb592d2156187a46, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &753899802 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 753899802, guid: 882e7ee053b171b45ab1de6a4236f84c,
+    type: 3}
+  m_PrefabInstance: {fileID: 3454874516297974168}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
@@ -4129,14 +4146,14 @@ MonoBehaviour:
   - {fileID: 702600011}
   - {fileID: 1056620604}
   InstrumentGameObjects:
-  - {fileID: 3454874516297974169}
+  - {fileID: 753899802}
   - {fileID: 1245230206}
   - {fileID: 1196938805}
   - {fileID: 1540282646}
   - {fileID: 742497890}
   - {fileID: 1750899207}
   - {fileID: 1486125177}
-  - {fileID: 8380348728054610297}
+  - {fileID: 2071385071}
 --- !u!114 &922758315
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5654,6 +5671,11 @@ PrefabInstance:
       propertyPath: m_zoomViewSpot
       value: 
       objectReference: {fileID: 1234077957}
+    - target: {fileID: 2841916218697318664, guid: b7de0512956c2a345825e8d099a17df1,
+        type: 3}
+      propertyPath: m_endMenu
+      value: 
+      objectReference: {fileID: 1872094742}
     - target: {fileID: 2841916218868793200, guid: b7de0512956c2a345825e8d099a17df1,
         type: 3}
       propertyPath: m_LocalPosition.z
@@ -7301,10 +7323,10 @@ RectTransform:
   m_Father: {fileID: 863764170}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: -100, y: -55}
+  m_SizeDelta: {x: 200, y: 80}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!114 &1697919283
 MonoBehaviour:
@@ -7370,7 +7392,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 922758315}
-        m_MethodName: EvaluateTask
+        m_MethodName: EndMenu_ClickYes
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -7950,12 +7972,12 @@ GameObject:
   - component: {fileID: 1872094746}
   - component: {fileID: 1872094745}
   m_Layer: 5
-  m_Name: AreYouSureConfirmInstruments
+  m_Name: EndMenu
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1872094743
 RectTransform:
   m_ObjectHideFlags: 0
@@ -7974,8 +7996,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 881, y: -213}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchoredPosition: {x: -19, y: 167}
+  m_SizeDelta: {x: -1960.5121, y: -1042.3153}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1872094745
 MonoBehaviour:
@@ -8289,7 +8311,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
   m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -8297,7 +8319,7 @@ MonoBehaviour:
   m_FontData:
     m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
     m_FontSize: 21
-    m_FontStyle: 0
+    m_FontStyle: 1
     m_BestFit: 0
     m_MinSize: 2
     m_MaxSize: 40
@@ -8528,6 +8550,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 2054188148}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &2071385071 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2071385071, guid: e783a9b9ecdbabd4aa6d9017003b40c8,
+    type: 3}
+  m_PrefabInstance: {fileID: 8380348728054610296}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 106d62bf4e5fc984cb592d2156187a46, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2076955852
 GameObject:
   m_ObjectHideFlags: 0
@@ -8851,10 +8885,10 @@ RectTransform:
   m_Father: {fileID: 863764170}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 300, y: -55}
+  m_SizeDelta: {x: 200, y: 80}
   m_Pivot: {x: 1, y: 0.5}
 --- !u!114 &2128910044
 MonoBehaviour:
@@ -8899,8 +8933,8 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 0}
-        m_MethodName: 
+      - m_Target: {fileID: 922758315}
+        m_MethodName: EndMenu_ClickNo
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -9237,22 +9271,22 @@ PrefabInstance:
     - target: {fileID: 4916199555798148860, guid: c7213e49952be9b49a5b18249c2c6c95,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4916199555798148860, guid: c7213e49952be9b49a5b18249c2c6c95,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4916199555798148860, guid: c7213e49952be9b49a5b18249c2c6c95,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4916199555798148860, guid: c7213e49952be9b49a5b18249c2c6c95,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4916199555798148860, guid: c7213e49952be9b49a5b18249c2c6c95,
         type: 3}
@@ -9262,12 +9296,12 @@ PrefabInstance:
     - target: {fileID: 4916199555798148860, guid: c7213e49952be9b49a5b18249c2c6c95,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4916199555798148860, guid: c7213e49952be9b49a5b18249c2c6c95,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4916199555798148860, guid: c7213e49952be9b49a5b18249c2c6c95,
         type: 3}
@@ -9480,7 +9514,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -23.164825}
+  m_AnchoredPosition: {x: 0, y: -23.164917}
   m_SizeDelta: {x: -400, y: -182.32999}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1452935737947872889
@@ -10338,7 +10372,7 @@ PrefabInstance:
     - target: {fileID: 1510955847047840570, guid: b50fb53d020fdac4f8473960e7f44623,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.037079677
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1510955847047840570, guid: b50fb53d020fdac4f8473960e7f44623,
         type: 3}
@@ -10348,7 +10382,7 @@ PrefabInstance:
     - target: {fileID: 1510955847047840570, guid: b50fb53d020fdac4f8473960e7f44623,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.99931234
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1510955847047840570, guid: b50fb53d020fdac4f8473960e7f44623,
         type: 3}
@@ -10363,7 +10397,7 @@ PrefabInstance:
     - target: {fileID: 1510955847047840570, guid: b50fb53d020fdac4f8473960e7f44623,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: -4.25
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1510955847047840570, guid: b50fb53d020fdac4f8473960e7f44623,
         type: 3}
@@ -10407,22 +10441,22 @@ PrefabInstance:
     - target: {fileID: 9092268366097555376, guid: e086447970a43194e801314d95653515,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 9092268366097555376, guid: e086447970a43194e801314d95653515,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 9092268366097555376, guid: e086447970a43194e801314d95653515,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 9092268366097555376, guid: e086447970a43194e801314d95653515,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 9092268366097555376, guid: e086447970a43194e801314d95653515,
         type: 3}
@@ -10437,7 +10471,7 @@ PrefabInstance:
     - target: {fileID: 9092268366097555376, guid: e086447970a43194e801314d95653515,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 180
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 9092268366097555376, guid: e086447970a43194e801314d95653515,
         type: 3}
@@ -10476,7 +10510,7 @@ PrefabInstance:
     - target: {fileID: 3454874516449610472, guid: 882e7ee053b171b45ab1de6a4236f84c,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.7071068
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3454874516449610472, guid: 882e7ee053b171b45ab1de6a4236f84c,
         type: 3}
@@ -10491,7 +10525,7 @@ PrefabInstance:
     - target: {fileID: 3454874516449610472, guid: 882e7ee053b171b45ab1de6a4236f84c,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3454874516449610472, guid: 882e7ee053b171b45ab1de6a4236f84c,
         type: 3}
@@ -10501,7 +10535,7 @@ PrefabInstance:
     - target: {fileID: 3454874516449610472, guid: 882e7ee053b171b45ab1de6a4236f84c,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3454874516449610472, guid: 882e7ee053b171b45ab1de6a4236f84c,
         type: 3}
@@ -10515,18 +10549,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 882e7ee053b171b45ab1de6a4236f84c, type: 3}
---- !u!114 &3454874516297974169 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 1885773633, guid: 882e7ee053b171b45ab1de6a4236f84c,
-    type: 3}
-  m_PrefabInstance: {fileID: 3454874516297974168}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 106d62bf4e5fc984cb592d2156187a46, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &3843762615708644309
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -10557,22 +10579,22 @@ PrefabInstance:
     - target: {fileID: 7824032710535489772, guid: 485d73ee977fbba4e906a193afa05542,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7824032710535489772, guid: 485d73ee977fbba4e906a193afa05542,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7824032710535489772, guid: 485d73ee977fbba4e906a193afa05542,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7824032710535489772, guid: 485d73ee977fbba4e906a193afa05542,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7824032710535489772, guid: 485d73ee977fbba4e906a193afa05542,
         type: 3}
@@ -10582,12 +10604,12 @@ PrefabInstance:
     - target: {fileID: 7824032710535489772, guid: 485d73ee977fbba4e906a193afa05542,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7824032710535489772, guid: 485d73ee977fbba4e906a193afa05542,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7824032710535489772, guid: 485d73ee977fbba4e906a193afa05542,
         type: 3}
@@ -10695,7 +10717,7 @@ PrefabInstance:
     - target: {fileID: 5906702258726912604, guid: f70a1a10fda7428499efbf231f95a673,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5906702258726912604, guid: f70a1a10fda7428499efbf231f95a673,
         type: 3}
@@ -10705,7 +10727,7 @@ PrefabInstance:
     - target: {fileID: 5906702258726912604, guid: f70a1a10fda7428499efbf231f95a673,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.000000749014
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5906702258726912604, guid: f70a1a10fda7428499efbf231f95a673,
         type: 3}
@@ -10720,7 +10742,7 @@ PrefabInstance:
     - target: {fileID: 5906702258726912604, guid: f70a1a10fda7428499efbf231f95a673,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 900
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5906702258726912604, guid: f70a1a10fda7428499efbf231f95a673,
         type: 3}
@@ -10749,7 +10771,7 @@ PrefabInstance:
     - target: {fileID: 5326187233620941838, guid: e783a9b9ecdbabd4aa6d9017003b40c8,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.0469
+      value: 1.104
       objectReference: {fileID: 0}
     - target: {fileID: 5326187233620941838, guid: e783a9b9ecdbabd4aa6d9017003b40c8,
         type: 3}
@@ -10764,17 +10786,17 @@ PrefabInstance:
     - target: {fileID: 5326187233620941838, guid: e783a9b9ecdbabd4aa6d9017003b40c8,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.7071068
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5326187233620941838, guid: e783a9b9ecdbabd4aa6d9017003b40c8,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.7071068
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5326187233620941838, guid: e783a9b9ecdbabd4aa6d9017003b40c8,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5326187233620941838, guid: e783a9b9ecdbabd4aa6d9017003b40c8,
         type: 3}
@@ -10784,12 +10806,12 @@ PrefabInstance:
     - target: {fileID: 5326187233620941838, guid: e783a9b9ecdbabd4aa6d9017003b40c8,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5326187233620941838, guid: e783a9b9ecdbabd4aa6d9017003b40c8,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 180
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5326187233620941838, guid: e783a9b9ecdbabd4aa6d9017003b40c8,
         type: 3}
@@ -10803,15 +10825,3 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e783a9b9ecdbabd4aa6d9017003b40c8, type: 3}
---- !u!114 &8380348728054610297 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 7583250013219598802, guid: e783a9b9ecdbabd4aa6d9017003b40c8,
-    type: 3}
-  m_PrefabInstance: {fileID: 8380348728054610296}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 106d62bf4e5fc984cb592d2156187a46, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 

--- a/VirtualTools/Assets/Scenes/SelectByName.unity
+++ b/VirtualTools/Assets/Scenes/SelectByName.unity
@@ -705,7 +705,8 @@ MonoBehaviour:
 
     Right Stick - rotate camera
 
-    A - Pick up/confirm instrument
+    A - Pick up/confirm
+    instrument
 
     B - Put instrument back
 
@@ -1659,18 +1660,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c916de4b1ab2b35448142b8876742f05, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &341965050 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 905469674935534915, guid: e783a9b9ecdbabd4aa6d9017003b40c8,
-    type: 3}
-  m_PrefabInstance: {fileID: 8380348728054610296}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 106d62bf4e5fc984cb592d2156187a46, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &359937775
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2228,7 +2217,7 @@ RectTransform:
   m_Children:
   - {fileID: 1452935738020663562}
   m_Father: {fileID: 1452935738757697057}
-  m_RootOrder: 4
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -3481,7 +3470,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: '<b>Left click/(A) button:</b>   select
 
-    <b>Right click/(B) button:</b> put back'
+    <b>Right click/(B) button:</b>
+    put back'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -4139,14 +4129,14 @@ MonoBehaviour:
   - {fileID: 702600011}
   - {fileID: 1056620604}
   InstrumentGameObjects:
-  - {fileID: 2069577646}
+  - {fileID: 3454874516297974169}
   - {fileID: 1245230206}
   - {fileID: 1196938805}
   - {fileID: 1540282646}
   - {fileID: 742497890}
   - {fileID: 1750899207}
   - {fileID: 1486125177}
-  - {fileID: 341965050}
+  - {fileID: 8380348728054610297}
 --- !u!114 &922758315
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4664,7 +4654,7 @@ RectTransform:
   - {fileID: 1117060237}
   - {fileID: 72595652}
   m_Father: {fileID: 1452935738757697057}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -5946,7 +5936,7 @@ RectTransform:
   - {fileID: 1664847897}
   - {fileID: 1120371358}
   m_Father: {fileID: 1452935738757697057}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -6032,7 +6022,7 @@ RectTransform:
   m_Children:
   - {fileID: 825693558}
   m_Father: {fileID: 1452935738757697057}
-  m_RootOrder: 2
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
@@ -6792,11 +6782,13 @@ MonoBehaviour:
 
     Mouse movement - rotate camera
 
-    Left Click - Pick up/confirm instrument
+    Left
+    Click - Pick up/confirm instrument
 
     Right Click - Put instrument back
 
-    Escape - Quit'
+    Escape
+    - Quit'
 --- !u!222 &1544250945
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -7496,11 +7488,12 @@ MonoBehaviour:
     session types on the right.
 
 
-    Follow the prompts in the upper-left hand corner to complete a task.
+    Follow the prompts in the upper-left hand corner
+    to complete a task.
 
 
-    Once all tasks have been completed the session will end and your results will
-    be displayed and uploaded.'
+    Once all tasks have been completed the session will
+    end and your results will be displayed and uploaded.'
 --- !u!222 &1714132299
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -7977,7 +7970,7 @@ RectTransform:
   - {fileID: 1964811641}
   - {fileID: 863764170}
   m_Father: {fileID: 1452935738757697057}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -8095,7 +8088,7 @@ RectTransform:
   m_Children:
   - {fileID: 963829369}
   m_Father: {fileID: 1452935738757697057}
-  m_RootOrder: 5
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -8213,79 +8206,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1939785359}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &2021600555
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2021600556}
-  - component: {fileID: 2021600558}
-  - component: {fileID: 2021600557}
-  m_Layer: 5
-  m_Name: Handle
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &2021600556
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2021600555}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 244516463}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 20, y: 20}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &2021600557
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2021600555}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &2021600558
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2021600555}
-  m_CullTransparentMesh: 0
 --- !u!114 &1948299625 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 459082684401764533, guid: 19ea898947e66c24cbd20d3d356c8026,
@@ -8387,8 +8307,8 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: Are you sure you would like to confirm your instrument positioning and end
-    the training session?
+  m_Text: Are you sure you would like to confirm your instrument positioning and
+    end the training session?
 --- !u!222 &1964811644
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -8396,6 +8316,79 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1964811640}
+  m_CullTransparentMesh: 0
+--- !u!1 &2021600555
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2021600556}
+  - component: {fileID: 2021600558}
+  - component: {fileID: 2021600557}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2021600556
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2021600555}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 244516463}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2021600557
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2021600555}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &2021600558
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2021600555}
   m_CullTransparentMesh: 0
 --- !u!1001 &2032800529
 PrefabInstance:
@@ -8535,18 +8528,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 2054188148}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &2069577646 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 3454874515643799204, guid: 882e7ee053b171b45ab1de6a4236f84c,
-    type: 3}
-  m_PrefabInstance: {fileID: 3454874516297974168}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 106d62bf4e5fc984cb592d2156187a46, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &2076955852
 GameObject:
   m_ObjectHideFlags: 0
@@ -9085,7 +9066,7 @@ PrefabInstance:
     - target: {fileID: 1747347944179239721, guid: f5793b8724356b84a98254e549ec16c8,
         type: 3}
       propertyPath: m_RootOrder
-      value: 10
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 1747347944179239721, guid: f5793b8724356b84a98254e549ec16c8,
         type: 3}
@@ -9276,7 +9257,7 @@ PrefabInstance:
     - target: {fileID: 4916199555798148860, guid: c7213e49952be9b49a5b18249c2c6c95,
         type: 3}
       propertyPath: m_RootOrder
-      value: 14
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 4916199555798148860, guid: c7213e49952be9b49a5b18249c2c6c95,
         type: 3}
@@ -9495,11 +9476,11 @@ RectTransform:
   - {fileID: 765860879}
   - {fileID: 522619479}
   m_Father: {fileID: 1452935738757697057}
-  m_RootOrder: 3
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -23.164856}
+  m_AnchoredPosition: {x: 0, y: -23.164825}
   m_SizeDelta: {x: -400, y: -182.32999}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1452935737947872889
@@ -10372,7 +10353,7 @@ PrefabInstance:
     - target: {fileID: 1510955847047840570, guid: b50fb53d020fdac4f8473960e7f44623,
         type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1510955847047840570, guid: b50fb53d020fdac4f8473960e7f44623,
         type: 3}
@@ -10446,7 +10427,7 @@ PrefabInstance:
     - target: {fileID: 9092268366097555376, guid: e086447970a43194e801314d95653515,
         type: 3}
       propertyPath: m_RootOrder
-      value: 13
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 9092268366097555376, guid: e086447970a43194e801314d95653515,
         type: 3}
@@ -10515,7 +10496,7 @@ PrefabInstance:
     - target: {fileID: 3454874516449610472, guid: 882e7ee053b171b45ab1de6a4236f84c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3454874516449610472, guid: 882e7ee053b171b45ab1de6a4236f84c,
         type: 3}
@@ -10534,6 +10515,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 882e7ee053b171b45ab1de6a4236f84c, type: 3}
+--- !u!114 &3454874516297974169 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1885773633, guid: 882e7ee053b171b45ab1de6a4236f84c,
+    type: 3}
+  m_PrefabInstance: {fileID: 3454874516297974168}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 106d62bf4e5fc984cb592d2156187a46, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &3843762615708644309
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -10584,7 +10577,7 @@ PrefabInstance:
     - target: {fileID: 7824032710535489772, guid: 485d73ee977fbba4e906a193afa05542,
         type: 3}
       propertyPath: m_RootOrder
-      value: 12
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 7824032710535489772, guid: 485d73ee977fbba4e906a193afa05542,
         type: 3}
@@ -10717,7 +10710,7 @@ PrefabInstance:
     - target: {fileID: 5906702258726912604, guid: f70a1a10fda7428499efbf231f95a673,
         type: 3}
       propertyPath: m_RootOrder
-      value: 11
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 5906702258726912604, guid: f70a1a10fda7428499efbf231f95a673,
         type: 3}
@@ -10786,7 +10779,7 @@ PrefabInstance:
     - target: {fileID: 5326187233620941838, guid: e783a9b9ecdbabd4aa6d9017003b40c8,
         type: 3}
       propertyPath: m_RootOrder
-      value: 15
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 5326187233620941838, guid: e783a9b9ecdbabd4aa6d9017003b40c8,
         type: 3}
@@ -10810,3 +10803,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e783a9b9ecdbabd4aa6d9017003b40c8, type: 3}
+--- !u!114 &8380348728054610297 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7583250013219598802, guid: e783a9b9ecdbabd4aa6d9017003b40c8,
+    type: 3}
+  m_PrefabInstance: {fileID: 8380348728054610296}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 106d62bf4e5fc984cb592d2156187a46, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/VirtualTools/Assets/Scenes/SelectByName.unity
+++ b/VirtualTools/Assets/Scenes/SelectByName.unity
@@ -122,6 +122,44 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &8670678
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8670679}
+  m_Layer: 0
+  m_Name: InstrumentPositionTaskSlots
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8670679
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8670678}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -2.671, y: 1.114, z: -1.2799366}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 446510651}
+  - {fileID: 776559008}
+  - {fileID: 68992363}
+  - {fileID: 1585830172}
+  - {fileID: 391631163}
+  - {fileID: 1332504193}
+  - {fileID: 788850397}
+  - {fileID: 907033205}
+  m_Father: {fileID: 0}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &32399720
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -323,6 +361,210 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 51214486}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &68992362
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8670679}
+    m_Modifications:
+    - target: {fileID: 4842086219158482387, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_Name
+      value: InstrumentPositioningTaskSlot (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.428
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.066
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 19ea898947e66c24cbd20d3d356c8026, type: 3}
+--- !u!4 &68992363 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+    type: 3}
+  m_PrefabInstance: {fileID: 68992362}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &72595651
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 72595652}
+  - component: {fileID: 72595655}
+  - component: {fileID: 72595654}
+  - component: {fileID: 72595653}
+  m_Layer: 5
+  m_Name: PositionInstrumentsButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &72595652
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 72595651}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 433016612}
+  m_Father: {fileID: 1059414757}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 1, y: 0.5}
+--- !u!114 &72595653
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 72595651}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 72595654}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1319623991}
+        m_MethodName: BeginSelectInstrumentPositionSession
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &72595654
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 72595651}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &72595655
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 72595651}
+  m_CullTransparentMesh: 0
 --- !u!1 &81182510
 GameObject:
   m_ObjectHideFlags: 0
@@ -1017,6 +1259,12 @@ Transform:
   - {fileID: 190828019}
   - {fileID: 2076955853}
   - {fileID: 1888794011}
+  - {fileID: 405867206}
+  - {fileID: 413917816}
+  - {fileID: 1850665277}
+  - {fileID: 816848662}
+  - {fileID: 702600012}
+  - {fileID: 1056620605}
   m_Father: {fileID: 0}
   m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1173,6 +1421,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 329608983}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &333717120 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 459082684401764533, guid: 19ea898947e66c24cbd20d3d356c8026,
+    type: 3}
+  m_PrefabInstance: {fileID: 1585830171}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c916de4b1ab2b35448142b8876742f05, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &341965050 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 905469674935534915, guid: e783a9b9ecdbabd4aa6d9017003b40c8,
@@ -1337,6 +1597,165 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 375439039}
   m_CullTransparentMesh: 0
+--- !u!1001 &391631162
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8670679}
+    m_Modifications:
+    - target: {fileID: 4842086219158482387, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_Name
+      value: InstrumentPositioningTaskSlot (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.855
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.066
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 19ea898947e66c24cbd20d3d356c8026, type: 3}
+--- !u!4 &391631163 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+    type: 3}
+  m_PrefabInstance: {fileID: 391631162}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &391631164 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 459082684401764533, guid: 19ea898947e66c24cbd20d3d356c8026,
+    type: 3}
+  m_PrefabInstance: {fileID: 391631162}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c916de4b1ab2b35448142b8876742f05, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &400573863 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 459082684401764533, guid: 19ea898947e66c24cbd20d3d356c8026,
+    type: 3}
+  m_PrefabInstance: {fileID: 68992362}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c916de4b1ab2b35448142b8876742f05, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &405867205
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 405867206}
+  m_Layer: 0
+  m_Name: Slot_9
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &405867206
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 405867205}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 1.909, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 232430803}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &413917815
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 413917816}
+  m_Layer: 0
+  m_Name: Slot_10
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &413917816
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 413917815}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 2.249, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 232430803}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &414033488
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1475,6 +1894,83 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 432744035}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &433016611
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 433016612}
+  - component: {fileID: 433016614}
+  - component: {fileID: 433016613}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &433016612
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 433016611}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 72595652}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -20, y: -20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &433016613
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 433016611}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 20
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Position Instruments for Surgery
+--- !u!222 &433016614
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 433016611}
+  m_CullTransparentMesh: 0
 --- !u!1 &443214025
 GameObject:
   m_ObjectHideFlags: 0
@@ -1549,6 +2045,81 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 443214025}
   m_CullTransparentMesh: 0
+--- !u!1001 &446510650
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8670679}
+    m_Modifications:
+    - target: {fileID: 4842086219158482387, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_Name
+      value: InstrumentPositioningTaskSlot
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.066
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 19ea898947e66c24cbd20d3d356c8026, type: 3}
+--- !u!4 &446510651 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+    type: 3}
+  m_PrefabInstance: {fileID: 446510650}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &456479022
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1639,6 +2210,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 456479022}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &470690623 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 459082684401764533, guid: 19ea898947e66c24cbd20d3d356c8026,
+    type: 3}
+  m_PrefabInstance: {fileID: 776559007}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c916de4b1ab2b35448142b8876742f05, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &498463775
 GameObject:
   m_ObjectHideFlags: 0
@@ -1885,6 +2468,113 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 613123943}
   m_CullTransparentMesh: 0
+--- !u!1 &660538666
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 660538667}
+  - component: {fileID: 660538669}
+  - component: {fileID: 660538668}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &660538667
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 660538666}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1697919282}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -20, y: -20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &660538668
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 660538666}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 21
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Yes
+--- !u!222 &660538669
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 660538666}
+  m_CullTransparentMesh: 0
+--- !u!1 &702600011
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 702600012}
+  m_Layer: 0
+  m_Name: Slot_13
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &702600012
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 702600011}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 3.135, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 232430803}
+  m_RootOrder: 12
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &742497890 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 6543683611350522616, guid: 485d73ee977fbba4e906a193afa05542,
@@ -1938,6 +2628,81 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &776559007
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8670679}
+    m_Modifications:
+    - target: {fileID: 4842086219158482387, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_Name
+      value: InstrumentPositioningTaskSlot (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.22
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.066
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 19ea898947e66c24cbd20d3d356c8026, type: 3}
+--- !u!4 &776559008 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+    type: 3}
+  m_PrefabInstance: {fileID: 776559007}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &781364655
 GameObject:
   m_ObjectHideFlags: 0
@@ -2043,6 +2808,93 @@ Transform:
   m_Father: {fileID: 232430803}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &788850396
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8670679}
+    m_Modifications:
+    - target: {fileID: 4842086219158482387, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_Name
+      value: InstrumentPositioningTaskSlot (6)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.263
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.066
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 19ea898947e66c24cbd20d3d356c8026, type: 3}
+--- !u!4 &788850397 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+    type: 3}
+  m_PrefabInstance: {fileID: 788850396}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &788850398 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 459082684401764533, guid: 19ea898947e66c24cbd20d3d356c8026,
+    type: 3}
+  m_PrefabInstance: {fileID: 788850396}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c916de4b1ab2b35448142b8876742f05, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &808885058
 GameObject:
   m_ObjectHideFlags: 0
@@ -2075,6 +2927,36 @@ Transform:
   - {fileID: 869880633}
   m_Father: {fileID: 0}
   m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &816848661
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 816848662}
+  m_Layer: 0
+  m_Name: Slot_12
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &816848662
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 816848661}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 2.905, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 232430803}
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &825693557
 GameObject:
@@ -2309,6 +3191,68 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 863120148}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &863764169
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 863764170}
+  - component: {fileID: 863764171}
+  m_Layer: 5
+  m_Name: GridLayout
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &863764170
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 863764169}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1697919282}
+  - {fileID: 2128910043}
+  m_Father: {fileID: 1872094743}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: -124}
+  m_SizeDelta: {x: 200, y: 80}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &863764171
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 863764169}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8a8695521f0d02e499659fee002a26c2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 10
+    m_Right: 10
+    m_Top: 40
+    m_Bottom: 10
+  m_ChildAlignment: 4
+  m_StartCorner: 0
+  m_StartAxis: 0
+  m_CellSize: {x: 200, y: 80}
+  m_Spacing: {x: 0, y: 0}
+  m_Constraint: 1
+  m_ConstraintCount: 2
 --- !u!1001 &864543066
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2540,6 +3484,93 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 895452001}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &907033204
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8670679}
+    m_Modifications:
+    - target: {fileID: 4842086219158482387, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_Name
+      value: InstrumentPositioningTaskSlot (7)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.464
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.066
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 19ea898947e66c24cbd20d3d356c8026, type: 3}
+--- !u!4 &907033205 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+    type: 3}
+  m_PrefabInstance: {fileID: 907033204}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &907033206 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 459082684401764533, guid: 19ea898947e66c24cbd20d3d356c8026,
+    type: 3}
+  m_PrefabInstance: {fileID: 907033204}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c916de4b1ab2b35448142b8876742f05, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &922758309
 GameObject:
   m_ObjectHideFlags: 0
@@ -2553,6 +3584,8 @@ GameObject:
   - component: {fileID: 922758312}
   - component: {fileID: 922758313}
   - component: {fileID: 922758314}
+  - component: {fileID: 922758315}
+  - component: {fileID: 922758316}
   m_Layer: 0
   m_Name: Managers
   m_TagString: Untagged
@@ -2634,6 +3667,12 @@ MonoBehaviour:
   - {fileID: 190828018}
   - {fileID: 2076955852}
   - {fileID: 1888794010}
+  - {fileID: 405867205}
+  - {fileID: 413917815}
+  - {fileID: 1850665276}
+  - {fileID: 816848661}
+  - {fileID: 702600011}
+  - {fileID: 1056620604}
   InstrumentGameObjects:
   - {fileID: 2069577646}
   - {fileID: 1245230206}
@@ -2643,6 +3682,41 @@ MonoBehaviour:
   - {fileID: 1750899207}
   - {fileID: 1486125177}
   - {fileID: 341965050}
+--- !u!114 &922758315
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 922758309}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 47122b1b04836d5458eca9bd5f191fa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &922758316
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 922758309}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 60d13bc78235f4840a771135c8e7bae1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Material: {fileID: 2100000, guid: e4942f02d8ecc984093e0081b20253f9, type: 2}
+  MaterialSelected: {fileID: 2100000, guid: f270d43c0b849ce4f9b0509f3f51f7d4, type: 2}
+  InstrumentSlots:
+  - {fileID: 1948299625}
+  - {fileID: 470690623}
+  - {fileID: 400573863}
+  - {fileID: 333717120}
+  - {fileID: 391631164}
+  - {fileID: 1332504194}
+  - {fileID: 788850398}
+  - {fileID: 907033206}
 --- !u!4 &939182960 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 3454874516449610472, guid: 882e7ee053b171b45ab1de6a4236f84c,
@@ -2984,6 +4058,36 @@ Transform:
   m_Father: {fileID: 232430803}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1056620604
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1056620605}
+  m_Layer: 0
+  m_Name: Slot_14
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1056620605
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1056620604}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 3.562, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 232430803}
+  m_RootOrder: 13
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1059414756
 GameObject:
   m_ObjectHideFlags: 0
@@ -3018,6 +4122,7 @@ RectTransform:
   - {fileID: 158060466}
   - {fileID: 1148691008}
   - {fileID: 1117060237}
+  - {fileID: 72595652}
   m_Father: {fileID: 1452935738757697057}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -4430,6 +5535,93 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1319809111}
   m_CullTransparentMesh: 0
+--- !u!1001 &1332504192
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8670679}
+    m_Modifications:
+    - target: {fileID: 4842086219158482387, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_Name
+      value: InstrumentPositioningTaskSlot (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.058
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.066
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 19ea898947e66c24cbd20d3d356c8026, type: 3}
+--- !u!4 &1332504193 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+    type: 3}
+  m_PrefabInstance: {fileID: 1332504192}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1332504194 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 459082684401764533, guid: 19ea898947e66c24cbd20d3d356c8026,
+    type: 3}
+  m_PrefabInstance: {fileID: 1332504192}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c916de4b1ab2b35448142b8876742f05, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1354472111
 GameObject:
   m_ObjectHideFlags: 0
@@ -5075,6 +6267,83 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1544250942}
   m_CullTransparentMesh: 0
+--- !u!1 &1546208752
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1546208753}
+  - component: {fileID: 1546208755}
+  - component: {fileID: 1546208754}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1546208753
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1546208752}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2128910043}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -20, y: -20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1546208754
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1546208752}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 21
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: No
+--- !u!222 &1546208755
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1546208752}
+  m_CullTransparentMesh: 0
 --- !u!1 &1575888445
 GameObject:
   m_ObjectHideFlags: 0
@@ -5114,6 +6383,81 @@ Transform:
   m_Father: {fileID: 808885059}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1585830171
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8670679}
+    m_Modifications:
+    - target: {fileID: 4842086219158482387, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_Name
+      value: InstrumentPositioningTaskSlot (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.649
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.066
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 19ea898947e66c24cbd20d3d356c8026, type: 3}
+--- !u!4 &1585830172 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8845084480710435644, guid: 19ea898947e66c24cbd20d3d356c8026,
+    type: 3}
+  m_PrefabInstance: {fileID: 1585830171}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1598628797
 GameObject:
   m_ObjectHideFlags: 0
@@ -5391,6 +6735,156 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1664847896}
+  m_CullTransparentMesh: 0
+--- !u!1 &1697919281
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1697919282}
+  - component: {fileID: 1697919286}
+  - component: {fileID: 1697919285}
+  - component: {fileID: 1697919284}
+  - component: {fileID: 1697919283}
+  m_Layer: 5
+  m_Name: Yes
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1697919282
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1697919281}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 660538667}
+  m_Father: {fileID: 863764170}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!114 &1697919283
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1697919281}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
+--- !u!114 &1697919284
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1697919281}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1697919285}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 922758315}
+        m_MethodName: EvaluateTask
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1697919285
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1697919281}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1697919286
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1697919281}
   m_CullTransparentMesh: 0
 --- !u!1 &1714132296
 GameObject:
@@ -5724,6 +7218,126 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1838259737}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1850665276
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1850665277}
+  m_Layer: 0
+  m_Name: Slot_11
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1850665277
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1850665276}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 2.576, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 232430803}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1872094742
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1872094743}
+  - component: {fileID: 1872094747}
+  - component: {fileID: 1872094746}
+  - component: {fileID: 1872094745}
+  m_Layer: 5
+  m_Name: AreYouSureConfirmInstruments
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1872094743
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1872094742}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1964811641}
+  - {fileID: 863764170}
+  m_Father: {fileID: 1452935738757697057}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 881, y: -213}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1872094745
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1872094742}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 2
+  m_VerticalFit: 2
+--- !u!114 &1872094746
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1872094742}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.754717, g: 0.754717, b: 0.754717, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1872094747
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1872094742}
+  m_CullTransparentMesh: 0
 --- !u!1 &1888794010
 GameObject:
   m_ObjectHideFlags: 0
@@ -5829,6 +7443,117 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1939785359}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1948299625 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 459082684401764533, guid: 19ea898947e66c24cbd20d3d356c8026,
+    type: 3}
+  m_PrefabInstance: {fileID: 446510650}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c916de4b1ab2b35448142b8876742f05, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1964811640
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1964811641}
+  - component: {fileID: 1964811644}
+  - component: {fileID: 1964811643}
+  - component: {fileID: 1964811642}
+  m_Layer: 5
+  m_Name: Title
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1964811641
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1964811640}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1872094743}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 400, y: 100}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!114 &1964811642
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1964811640}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 1
+  m_MinWidth: 400
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
+--- !u!114 &1964811643
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1964811640}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 21
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Are you sure you would like to confirm your instrument positioning and
+    end the training session?
+--- !u!222 &1964811644
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1964811640}
+  m_CullTransparentMesh: 0
 --- !u!1001 &2032800529
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6268,6 +7993,135 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 2127811160}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &2128910042
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2128910043}
+  - component: {fileID: 2128910046}
+  - component: {fileID: 2128910045}
+  - component: {fileID: 2128910044}
+  m_Layer: 5
+  m_Name: No
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2128910043
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2128910042}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1546208753}
+  m_Father: {fileID: 863764170}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 1, y: 0.5}
+--- !u!114 &2128910044
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2128910042}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 2128910045}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 0}
+        m_MethodName: 
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &2128910045
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2128910042}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &2128910046
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2128910042}
+  m_CullTransparentMesh: 0
 --- !u!1001 &2132894029
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7181,6 +9035,7 @@ RectTransform:
   - {fileID: 1059414757}
   - {fileID: 443214026}
   - {fileID: 1319809112}
+  - {fileID: 1872094743}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/VirtualTools/Assets/Scripts/GUI/SessionTypeSelector.cs
+++ b/VirtualTools/Assets/Scripts/GUI/SessionTypeSelector.cs
@@ -17,4 +17,12 @@ public class SessionTypeSelector : MonoBehaviour
 		GUIManager.Instance.GetMainCanvas().SetEscapeMenu(false);
 		GUIManager.Instance.GetMainCanvas().SetSceneSelector(false);
 	}
+
+	public void BeginSelectInstrumentPositionSession()
+	{
+		SessionManager.Instance.CreateSelectByPurposeSession();
+		GUIManager.Instance.ConfigureCursor(false, CursorLockMode.Locked);
+		GUIManager.Instance.GetMainCanvas().SetEscapeMenu(false);
+		GUIManager.Instance.GetMainCanvas().SetSceneSelector(false);
+	}
 }

--- a/VirtualTools/Assets/Scripts/GUI/SessionTypeSelector.cs
+++ b/VirtualTools/Assets/Scripts/GUI/SessionTypeSelector.cs
@@ -20,7 +20,7 @@ public class SessionTypeSelector : MonoBehaviour
 
 	public void BeginSelectInstrumentPositionSession()
 	{
-		SessionManager.Instance.CreateSelectByPurposeSession();
+		SessionManager.Instance.CreateInstrumentPositioningSession();
 		GUIManager.Instance.ConfigureCursor(false, CursorLockMode.Locked);
 		GUIManager.Instance.GetMainCanvas().SetEscapeMenu(false);
 		GUIManager.Instance.GetMainCanvas().SetSceneSelector(false);

--- a/VirtualTools/Assets/Scripts/Instrument/Instrument.cs
+++ b/VirtualTools/Assets/Scripts/Instrument/Instrument.cs
@@ -26,14 +26,14 @@ public class Instrument : MonoBehaviour, IInstrumentSelectable
     // Start is called before the first frame update
     void Start()
     {
-        m_renderer = GetComponent<MeshRenderer>();
+        m_renderer = GetComponentInChildren<MeshRenderer>();
         originalPosition = transform.position;
         originalRotation = transform.rotation;
     }
 
-        public void OnPointing()
+    public void OnPointing()
     {
-        foreach (Material mat in GetComponent<Renderer>().materials)
+        foreach (Material mat in GetComponentInChildren<Renderer>().materials)
         {
             mat.color = Color.green;
         }
@@ -41,7 +41,7 @@ public class Instrument : MonoBehaviour, IInstrumentSelectable
 
     public void OnReleasedPointing()
     {
-        foreach (Material mat in GetComponent<Renderer>().materials)
+        foreach (Material mat in GetComponentInChildren<Renderer>().materials)
         {
             mat.color = Color.white;
         }

--- a/VirtualTools/Assets/Scripts/Instrument/Instrument.cs
+++ b/VirtualTools/Assets/Scripts/Instrument/Instrument.cs
@@ -31,38 +31,21 @@ public class Instrument : MonoBehaviour, IInstrumentSelectable
         originalRotation = transform.rotation;
     }
 
-
-    public void OnPointing()
-
+        public void OnPointing()
     {
-    
-	foreach(Material mat in GetComponent<Renderer>().materials)
-    
-	{
-	
-		mat.color = Color.green;
-
-    	}
-    
+        foreach (Material mat in GetComponent<Renderer>().materials)
+        {
+            mat.color = Color.green;
+        }
     }
-
-    
 
     public void OnReleasedPointing()
-    
     {
-        
-	foreach(Material mat in GetComponent<Renderer>().materials)
-
-	{
-            
-		mat.color = Color.white;
-        
-	}
-        
-    
+        foreach (Material mat in GetComponent<Renderer>().materials)
+        {
+            mat.color = Color.white;
+        }
     }
-   
 
     public static string GetName(INSTRUMENT_TAG tag)
     {
@@ -84,8 +67,10 @@ public class Instrument : MonoBehaviour, IInstrumentSelectable
                 return "Suture Scissor";
             case INSTRUMENT_TAG.TOWEL_CLAMPS:
                 return "Towel Clamps";
+            case INSTRUMENT_TAG.NONE:
+                return "None";
             default:
-                throw new System.Exception("Purpose description for instrument tag " + tag + " does not exist.");
+                throw new System.Exception("Name for instrument tag " + tag + " does not exist.");
         }
     }
     public static INSTRUMENT_TAG GetInstrumentTagFromString(string str)

--- a/VirtualTools/Assets/Scripts/Instrument/InstrumentPositionTaskSlot.cs
+++ b/VirtualTools/Assets/Scripts/Instrument/InstrumentPositionTaskSlot.cs
@@ -6,4 +6,47 @@ public class InstrumentPositionTaskSlot : MonoBehaviour
 {
     public Instrument.INSTRUMENT_TAG CurrentInstrument;
     public Instrument.INSTRUMENT_TAG CorrectInstrument;
+
+    public void OnPointing()
+    {
+        foreach (Material mat in GetComponent<Renderer>().materials)
+        {
+            mat.color = new Color(0, 1, 0, 0.5f);
+        }
+    }
+
+    public void OnReleasedPointing()
+    {
+        foreach (Material mat in GetComponent<Renderer>().materials)
+        {
+            mat.color = new Color(1,1,1,0.5f);
+        }
+    }
+
+    /*
+
+    private void Start()
+    {
+        for (int i = 0; i < GetComponent<Renderer>().materials.Length; i++)
+        {
+            GetComponent<Renderer>().materials[i] = InstrumentPositionTaskLocManager.Instance.Material;
+        }
+    }
+
+    public void OnPointing()
+    {
+        for (int i = 0; i < GetComponent<Renderer>().materials.Length; i++)
+        {
+            GetComponent<Renderer>().materials[i] = InstrumentPositionTaskLocManager.Instance.MaterialSelected;
+        }
+    }
+
+    public void OnReleasedPointing()
+    {
+        for (int i = 0; i < GetComponent<Renderer>().materials.Length; i++)
+        {
+            GetComponent<Renderer>().materials[i] = InstrumentPositionTaskLocManager.Instance.Material;
+        }
+    }
+    */
 }

--- a/VirtualTools/Assets/Scripts/Instrument/InstrumentPositionTaskSlot.cs
+++ b/VirtualTools/Assets/Scripts/Instrument/InstrumentPositionTaskSlot.cs
@@ -23,30 +23,11 @@ public class InstrumentPositionTaskSlot : MonoBehaviour
         }
     }
 
-    /*
-
     private void Start()
     {
-        for (int i = 0; i < GetComponent<Renderer>().materials.Length; i++)
+        foreach (Material mat in GetComponent<Renderer>().materials)
         {
-            GetComponent<Renderer>().materials[i] = InstrumentPositionTaskLocManager.Instance.Material;
+            mat.color = new Color(1, 1, 1, 0.5f);
         }
     }
-
-    public void OnPointing()
-    {
-        for (int i = 0; i < GetComponent<Renderer>().materials.Length; i++)
-        {
-            GetComponent<Renderer>().materials[i] = InstrumentPositionTaskLocManager.Instance.MaterialSelected;
-        }
-    }
-
-    public void OnReleasedPointing()
-    {
-        for (int i = 0; i < GetComponent<Renderer>().materials.Length; i++)
-        {
-            GetComponent<Renderer>().materials[i] = InstrumentPositionTaskLocManager.Instance.Material;
-        }
-    }
-    */
 }

--- a/VirtualTools/Assets/Scripts/Instrument/InstrumentPositionTaskSlot.cs
+++ b/VirtualTools/Assets/Scripts/Instrument/InstrumentPositionTaskSlot.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class InstrumentPositionTaskSlot : MonoBehaviour
+{
+    public Instrument.INSTRUMENT_TAG CurrentInstrument;
+    public Instrument.INSTRUMENT_TAG CorrectInstrument;
+}

--- a/VirtualTools/Assets/Scripts/Instrument/InstrumentPositionTaskSlot.cs
+++ b/VirtualTools/Assets/Scripts/Instrument/InstrumentPositionTaskSlot.cs
@@ -9,9 +9,12 @@ public class InstrumentPositionTaskSlot : MonoBehaviour
 
     public void OnPointing()
     {
-        foreach (Material mat in GetComponent<Renderer>().materials)
+        if(CurrentInstrument == Instrument.INSTRUMENT_TAG.NONE)
         {
-            mat.color = new Color(0, 1, 0, 0.5f);
+            foreach (Material mat in GetComponent<Renderer>().materials)
+            {
+                mat.color = new Color(0, 1, 0, 0.5f);
+            }
         }
     }
 

--- a/VirtualTools/Assets/Scripts/Instrument/InstrumentPositionTaskSlot.cs.meta
+++ b/VirtualTools/Assets/Scripts/Instrument/InstrumentPositionTaskSlot.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c916de4b1ab2b35448142b8876742f05
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VirtualTools/Assets/Scripts/Managers/InstrumentLocManager.cs
+++ b/VirtualTools/Assets/Scripts/Managers/InstrumentLocManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Assertions;
@@ -73,16 +74,8 @@ public class InstrumentLocManager : MonoBehaviour
         {
             if(instrument != Instrument.INSTRUMENT_TAG.NONE)
             {
-                // Get the instrument with each tag in the instrument gameobject list.
-                // Also ensure there's no repeated instruments gameobjects.
-                List<Instrument> taggedGameObjects = InstrumentGameObjects.FindAll(a => a.instrumentTag == instrument);
-            	Assert.AreEqual(taggedGameObjects.Count, 1, "Duplicate INSTRUMENT_TAG in the InstrumentGameObjects");
-                Instrument instrumentToPlace = taggedGameObjects[0];
                 Assert.IsTrue(InstrumentLocationSlots.Count > i);
-                Instantiate<GameObject>(instrumentToPlace.gameObject,
-                    InstrumentLocationSlots[i].transform.position,
-                    instrumentToPlace.transform.rotation,
-                    InstrumentLocationSlots[i].transform);
+                PlaceInstrument(instrument, InstrumentLocationSlots[i]);
             }
             ++i;
         }
@@ -98,5 +91,21 @@ public class InstrumentLocManager : MonoBehaviour
     void Update()
     {
         
+    }
+
+    internal void PlaceInstrument(Instrument.INSTRUMENT_TAG instrument, GameObject parent)
+    {
+        // Get the instrument with each tag in the instrument gameobject list.
+        // Also ensure there's no repeated instruments in the template list.
+        List<Instrument> taggedGameObjects = InstrumentGameObjects.FindAll(a => a.instrumentTag == instrument);
+        Assert.AreEqual(taggedGameObjects.Count, 1, "Duplicate INSTRUMENT_TAG in the InstrumentGameObjects");
+        Instrument instrumentToPlace = taggedGameObjects[0];
+        var obj = Instantiate<GameObject>(instrumentToPlace.gameObject);
+        obj.transform.position = parent.transform.position;
+        /*,
+            parent.transform.position,
+            instrumentToPlace.transform.rotation,
+            parent.transform);
+        obj.transform.s = instrumentToPlace.transform.localScale;*/
     }
 }

--- a/VirtualTools/Assets/Scripts/Managers/InstrumentLocManager.cs
+++ b/VirtualTools/Assets/Scripts/Managers/InstrumentLocManager.cs
@@ -38,7 +38,7 @@ public class InstrumentLocManager : MonoBehaviour
     List<GameObject> InstrumentLocationSlots;
 
     /// <summary>
-    /// Instrument monobehaviours for instrument gameobjects in the scene that will be moved to the correct scene location.
+    /// Instrument monobehaviours for instrument gameobjects in the scene that will be instantiated in the correct scene location.
     /// </summary>
     [SerializeField]
     List<Instrument> InstrumentGameObjects;
@@ -78,15 +78,13 @@ public class InstrumentLocManager : MonoBehaviour
                 // Also ensure there's no repeated instruments gameobjects.
                 List<Instrument> taggedGameObjects = InstrumentGameObjects.FindAll(a => a.instrumentTag == instrument);
             	Assert.AreEqual(taggedGameObjects.Count, 1, "Duplicate INSTRUMENT_TAG in the InstrumentGameObjects");
-                Instrument instrumentToMove = taggedGameObjects[0];
-                // Ensure there's no repeats of the current item in the ordered list that was sent through.
-            	List<Instrument.INSTRUMENT_TAG> instrumentRepeatedTags = instrumentsOrder.FindAll(b => b == instrument);
-            	Assert.AreEqual(instrumentRepeatedTags.Count, 1, "Duplicate INSTRUMENT_TAG in the instrumentsOrder parameter");
+                Instrument instrumentToPlace = taggedGameObjects[0];
                 // Place the instrument gameobject in the desired location and unhide it
                 Assert.IsTrue(InstrumentLocationSlots.Count > i);
-                instrumentToMove.gameObject.transform.SetParent(InstrumentLocationSlots[i].transform);
-                instrumentToMove.gameObject.transform.localPosition = new Vector3();
-                instrumentToMove.gameObject.SetActive(true);
+                Instantiate<GameObject>(instrumentToPlace.gameObject,
+                    InstrumentLocationSlots[i].transform.position,
+                    instrumentToPlace.transform.rotation,
+                    InstrumentLocationSlots[i].transform);
             }
             ++i;
         }

--- a/VirtualTools/Assets/Scripts/Managers/InstrumentLocManager.cs
+++ b/VirtualTools/Assets/Scripts/Managers/InstrumentLocManager.cs
@@ -110,10 +110,14 @@ public class InstrumentLocManager : MonoBehaviour
     public void MoveInstrument(GameObject instrument, GameObject parent)
     {
         instrument.transform.parent = parent.transform;
+        instrument.transform.position = parent.transform.position;
+        //instrument.transform.localScale = instrumentToPlace.transform.localScale;
+        instrument.transform.rotation = new Quaternion();
+
     }
     public void MoveInstrumentToPlayer(GameObject instrument, GameObject parent)
     {
         instrument.transform.parent = parent.transform;
-        instrument.transform.position = Camera.main.transform.position + Camera.main.transform.forward * 0.1f;
+        instrument.transform.position = Camera.main.transform.position + Camera.main.transform.forward * 0.3f;
     }
 }

--- a/VirtualTools/Assets/Scripts/Managers/InstrumentLocManager.cs
+++ b/VirtualTools/Assets/Scripts/Managers/InstrumentLocManager.cs
@@ -103,10 +103,17 @@ public class InstrumentLocManager : MonoBehaviour
         var obj = Instantiate<GameObject>(instrumentToPlace.gameObject);
         obj.transform.position = parent.transform.position;
         obj.transform.localScale = instrumentToPlace.transform.localScale;
-        /*,
-            parent.transform.position,
-            instrumentToPlace.transform.rotation,
-            parent.transform);
-        obj.transform.s = instrumentToPlace.transform.localScale;*/
+        obj.transform.rotation = new Quaternion();
+        obj.transform.parent = parent.transform;
+    }
+
+    public void MoveInstrument(GameObject instrument, GameObject parent)
+    {
+        instrument.transform.parent = parent.transform;
+    }
+    public void MoveInstrumentToPlayer(GameObject instrument, GameObject parent)
+    {
+        instrument.transform.parent = parent.transform;
+        instrument.transform.position = Camera.main.transform.position + Camera.main.transform.forward * 0.1f;
     }
 }

--- a/VirtualTools/Assets/Scripts/Managers/InstrumentLocManager.cs
+++ b/VirtualTools/Assets/Scripts/Managers/InstrumentLocManager.cs
@@ -111,7 +111,6 @@ public class InstrumentLocManager : MonoBehaviour
     {
         instrument.transform.parent = parent.transform;
         instrument.transform.position = parent.transform.position;
-        //instrument.transform.localScale = instrumentToPlace.transform.localScale;
         instrument.transform.rotation = new Quaternion();
 
     }

--- a/VirtualTools/Assets/Scripts/Managers/InstrumentLocManager.cs
+++ b/VirtualTools/Assets/Scripts/Managers/InstrumentLocManager.cs
@@ -43,7 +43,6 @@ public class InstrumentLocManager : MonoBehaviour
     [SerializeField]
     List<Instrument> InstrumentGameObjects;
 
-
     public static List<Instrument.INSTRUMENT_TAG> CurrentInstrumentOrder { get; set; }
 
     /// <summary>
@@ -79,7 +78,6 @@ public class InstrumentLocManager : MonoBehaviour
                 List<Instrument> taggedGameObjects = InstrumentGameObjects.FindAll(a => a.instrumentTag == instrument);
             	Assert.AreEqual(taggedGameObjects.Count, 1, "Duplicate INSTRUMENT_TAG in the InstrumentGameObjects");
                 Instrument instrumentToPlace = taggedGameObjects[0];
-                // Place the instrument gameobject in the desired location and unhide it
                 Assert.IsTrue(InstrumentLocationSlots.Count > i);
                 Instantiate<GameObject>(instrumentToPlace.gameObject,
                     InstrumentLocationSlots[i].transform.position,

--- a/VirtualTools/Assets/Scripts/Managers/InstrumentLocManager.cs
+++ b/VirtualTools/Assets/Scripts/Managers/InstrumentLocManager.cs
@@ -48,7 +48,7 @@ public class InstrumentLocManager : MonoBehaviour
     /// <summary>
     /// Order the instruments in the order given by the string.
     /// </summary>
-    /// <param name="instruments">String representing a list of instruments tags. Each one must be unique. 
+    /// <param name="instruments">String representing a list of instruments tags.
     /// Number of instruments in the list must be <= than the number of InstrumentLocationSlots.</param>
     public void PlaceInstrumentsInOrder(string instrumentsString)
     {
@@ -63,7 +63,7 @@ public class InstrumentLocManager : MonoBehaviour
     /// <summary>
     /// Order the instruments. (internal method)
     /// </summary>
-    /// <param name="instruments">List of instruments. Each one must be unique. 
+    /// <param name="instruments">List of instruments.
     /// Must not be larger in size than the number of InstrumentLocationSlots.</param>
     public void PlaceInstrumentsInOrder(List<Instrument.INSTRUMENT_TAG> instrumentsOrder)
     {

--- a/VirtualTools/Assets/Scripts/Managers/InstrumentLocManager.cs
+++ b/VirtualTools/Assets/Scripts/Managers/InstrumentLocManager.cs
@@ -93,7 +93,7 @@ public class InstrumentLocManager : MonoBehaviour
         
     }
 
-    internal void PlaceInstrument(Instrument.INSTRUMENT_TAG instrument, GameObject parent)
+    public void PlaceInstrument(Instrument.INSTRUMENT_TAG instrument, GameObject parent)
     {
         // Get the instrument with each tag in the instrument gameobject list.
         // Also ensure there's no repeated instruments in the template list.
@@ -102,6 +102,7 @@ public class InstrumentLocManager : MonoBehaviour
         Instrument instrumentToPlace = taggedGameObjects[0];
         var obj = Instantiate<GameObject>(instrumentToPlace.gameObject);
         obj.transform.position = parent.transform.position;
+        obj.transform.localScale = instrumentToPlace.transform.localScale;
         /*,
             parent.transform.position,
             instrumentToPlace.transform.rotation,

--- a/VirtualTools/Assets/Scripts/Managers/InstrumentPositionTaskLocManager.cs
+++ b/VirtualTools/Assets/Scripts/Managers/InstrumentPositionTaskLocManager.cs
@@ -63,7 +63,7 @@ public class InstrumentPositionTaskLocManager : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        PlaceDesiredSlotsInOrder("Scalpel,Scalpel,Scalpel,Scalpel");
+        PlaceDesiredSlotsInOrder("Scalpel,Scalpel,Scalpel,Scalpel,Scalpel,Scalpel,Scalpel,Scalpel");
 
     }
 

--- a/VirtualTools/Assets/Scripts/Managers/InstrumentPositionTaskLocManager.cs
+++ b/VirtualTools/Assets/Scripts/Managers/InstrumentPositionTaskLocManager.cs
@@ -1,0 +1,103 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Assertions;
+
+/// <summary>
+/// Organises the expected instruments in the instrument slots for the
+/// instrument position task based on the active layout.
+/// </summary>
+public class InstrumentPositionTaskLocManager : MonoBehaviour
+{
+    private static InstrumentPositionTaskLocManager m_instance;
+    public static InstrumentPositionTaskLocManager Instance
+    {
+        get
+        {
+            if (m_instance == null)
+            {
+                GameObject coreGameObject = GameObject.Find("Managers");
+                m_instance = coreGameObject.AddComponent<InstrumentPositionTaskLocManager>();
+            }
+
+            return m_instance;
+        }
+    }
+
+    protected virtual void Awake()
+    {
+        if (m_instance == null)
+            m_instance = GetComponent<InstrumentPositionTaskLocManager>();
+        else
+            DestroyImmediate(this);
+    }
+
+    /// <summary>
+    /// Gameobjects representing locations where instruments can go.
+    /// </summary>
+    [SerializeField]
+    List<GameObject> InstrumentLocationSlots;
+
+    /// <summary>
+    /// Instrument monobehaviours for instrument gameobjects in the scene that will be moved to the correct scene location.
+    /// </summary>
+    [SerializeField]
+    List<Instrument> InstrumentGameObjects;
+
+
+    public static List<Instrument.INSTRUMENT_TAG> CurrentInstrumentOrder { get; set; }
+
+    /// <summary>
+    /// Order the instruments in the order given by the string.
+    /// </summary>
+    /// <param name="instruments">String representing a list of instruments tags. Each one must be unique. 
+    /// Number of instruments in the list must be <= than the number of InstrumentLocationSlots.</param>
+    public void PlaceInstrumentsInOrder(string instrumentsString)
+    {
+        string[] instrumentsSplit = instrumentsString.Split(',');
+        List<Instrument.INSTRUMENT_TAG> instrumentTags = new List<Instrument.INSTRUMENT_TAG>();
+        foreach (var instrumentTagString in instrumentsSplit)
+        {
+            instrumentTags.Add(Instrument.GetInstrumentTagFromString(instrumentTagString));
+        }
+        PlaceInstrumentsInOrder(instrumentTags);
+    }
+    /// <summary>
+    /// Order the instruments. (internal method)
+    /// </summary>
+    /// <param name="instruments">List of instruments. Each one must be unique. 
+    /// Must not be larger in size than the number of InstrumentLocationSlots.</param>
+    public void PlaceInstrumentsInOrder(List<Instrument.INSTRUMENT_TAG> instrumentsOrder)
+    {
+        CurrentInstrumentOrder = instrumentsOrder;
+        int i = 0;
+        foreach(Instrument.INSTRUMENT_TAG instrument in instrumentsOrder)
+        {
+            if(instrument != Instrument.INSTRUMENT_TAG.NONE)
+            {
+                // Get the instrument with each tag in the instrument gameobject list.
+                // Also ensure there's no repeated instruments gameobjects.
+                List<Instrument> taggedGameObjects = InstrumentGameObjects.FindAll(a => a.instrumentTag == instrument);
+            	Assert.AreEqual(taggedGameObjects.Count, 1, "Duplicate INSTRUMENT_TAG in the InstrumentGameObjects");
+                Instrument instrumentToPlace = taggedGameObjects[0];
+                // Place the instrument gameobject in the desired location and unhide it
+                Assert.IsTrue(InstrumentLocationSlots.Count > i);
+                Instantiate<GameObject>(instrumentToPlace.gameObject, InstrumentLocationSlots[i].transform);
+                instrumentToPlace.gameObject.transform.localPosition = new Vector3();
+            }
+            ++i;
+        }
+    }
+
+    // Start is called before the first frame update
+    void Start()
+    {
+
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+}

--- a/VirtualTools/Assets/Scripts/Managers/InstrumentPositionTaskLocManager.cs
+++ b/VirtualTools/Assets/Scripts/Managers/InstrumentPositionTaskLocManager.cs
@@ -54,7 +54,7 @@ public class InstrumentPositionTaskLocManager : MonoBehaviour
         int i = 0;
         foreach (Instrument.INSTRUMENT_TAG instrument in instrumentsOrder)
         {
-            Assert.IsTrue(InstrumentSlots.Count > i);
+            Assert.IsTrue(InstrumentSlots.Count > i,"Number of slots in the scene is less than the number of slots being configured");
             InstrumentSlots[i].CorrectInstrument = instrumentsOrder[i];
             ++i;
         }
@@ -63,8 +63,7 @@ public class InstrumentPositionTaskLocManager : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        PlaceDesiredSlotsInOrder("Scalpel,Scalpel,Scalpel,Scalpel,Scalpel,Scalpel,Scalpel,Scalpel");
-
+        PlaceDesiredSlotsInOrder("Scalpel,Addson-Brown Forceps,Metzembaum Scissors,Mayo Scissors,Suture Scissors,Mayo Hegar Needle Driver,Rochester Carmalt Forceps,Towel Clamps");
     }
 
     // Update is called once per frame

--- a/VirtualTools/Assets/Scripts/Managers/InstrumentPositionTaskLocManager.cs
+++ b/VirtualTools/Assets/Scripts/Managers/InstrumentPositionTaskLocManager.cs
@@ -36,14 +36,9 @@ public class InstrumentPositionTaskLocManager : MonoBehaviour
     /// <summary>
     /// Gameobjects representing slots where instruments can be placed.
     /// </summary>
-    public List<InstrumentPositionTaskSlot> InstrumentSlots { get; set; }
-
-    /// <summary>
-    /// Order the expected instruments in each slot in the order given by the string.
-    /// </summary>
-    /// <param name="instruments">String representing a list of instruments tags.
-    /// Number of instruments in the list must be <= than the number of InstrumentLocationSlots.</param>
-    public void PlaceInstrumentsInOrder(string instrumentsString)
+    public List<InstrumentPositionTaskSlot> InstrumentSlots;
+    
+    public void PlaceDesiredSlotsInOrder(string instrumentsString)
     {
         string[] instrumentsSplit = instrumentsString.Split(',');
         List<Instrument.INSTRUMENT_TAG> instrumentTags = new List<Instrument.INSTRUMENT_TAG>();
@@ -51,39 +46,24 @@ public class InstrumentPositionTaskLocManager : MonoBehaviour
         {
             instrumentTags.Add(Instrument.GetInstrumentTagFromString(instrumentTagString));
         }
-        PlaceInstrumentsInOrder(instrumentTags);
+        PlaceDesiredSlotsInOrder(instrumentTags);
     }
-    /// <summary>
-    /// Order the expected instruments in each slot. (internal method)
-    /// </summary>
-    /// <param name="instruments">List of instruments.
-    /// Must not be larger in size than the number of InstrumentLocationSlots.</param>
-    public void PlaceInstrumentsInOrder(List<Instrument.INSTRUMENT_TAG> instrumentsOrder)
+    
+    public void PlaceDesiredSlotsInOrder(List<Instrument.INSTRUMENT_TAG> instrumentsOrder)
     {
-        /*
-        CurrentInstrumentOrder = instrumentsOrder;
         int i = 0;
-        foreach(Instrument.INSTRUMENT_TAG instrument in instrumentsOrder)
+        foreach (Instrument.INSTRUMENT_TAG instrument in instrumentsOrder)
         {
-            if(instrument != Instrument.INSTRUMENT_TAG.NONE)
-            {
-                // Get the instrument with each tag in the instrument gameobject list.
-                // Also ensure there's no repeated instruments gameobjects.
-                List<Instrument> taggedGameObjects = InstrumentGameObjects.FindAll(a => a.instrumentTag == instrument);
-            	Assert.AreEqual(taggedGameObjects.Count, 1, "Duplicate INSTRUMENT_TAG in the InstrumentGameObjects");
-                Instrument instrumentToPlace = taggedGameObjects[0];
-                Assert.IsTrue(InstrumentSlots.Count > i);
-                Instantiate<GameObject>(instrumentToPlace.gameObject, InstrumentSlots[i].transform);
-                instrumentToPlace.gameObject.transform.localPosition = new Vector3();
-            }
+            Assert.IsTrue(InstrumentSlots.Count > i);
+            InstrumentSlots[i].CorrectInstrument = instrumentsOrder[i];
             ++i;
         }
-        */
     }
 
     // Start is called before the first frame update
     void Start()
     {
+        PlaceDesiredSlotsInOrder("Scalpel,Scalpel,Scalpel,Scalpel");
 
     }
 

--- a/VirtualTools/Assets/Scripts/Managers/InstrumentPositionTaskLocManager.cs
+++ b/VirtualTools/Assets/Scripts/Managers/InstrumentPositionTaskLocManager.cs
@@ -39,18 +39,9 @@ public class InstrumentPositionTaskLocManager : MonoBehaviour
     public List<InstrumentPositionTaskSlot> InstrumentSlots { get; set; }
 
     /// <summary>
-    /// Instrument monobehaviours for instrument gameobjects in the scene that will be moved to the correct scene location.
+    /// Order the expected instruments in each slot in the order given by the string.
     /// </summary>
-    [SerializeField]
-    List<Instrument> InstrumentGameObjects;
-
-
-    public static List<Instrument.INSTRUMENT_TAG> CurrentInstrumentOrder { get; set; }
-
-    /// <summary>
-    /// Order the instruments in the order given by the string.
-    /// </summary>
-    /// <param name="instruments">String representing a list of instruments tags. Each one must be unique. 
+    /// <param name="instruments">String representing a list of instruments tags.
     /// Number of instruments in the list must be <= than the number of InstrumentLocationSlots.</param>
     public void PlaceInstrumentsInOrder(string instrumentsString)
     {
@@ -63,12 +54,13 @@ public class InstrumentPositionTaskLocManager : MonoBehaviour
         PlaceInstrumentsInOrder(instrumentTags);
     }
     /// <summary>
-    /// Order the instruments. (internal method)
+    /// Order the expected instruments in each slot. (internal method)
     /// </summary>
-    /// <param name="instruments">List of instruments. Each one must be unique. 
+    /// <param name="instruments">List of instruments.
     /// Must not be larger in size than the number of InstrumentLocationSlots.</param>
     public void PlaceInstrumentsInOrder(List<Instrument.INSTRUMENT_TAG> instrumentsOrder)
     {
+        /*
         CurrentInstrumentOrder = instrumentsOrder;
         int i = 0;
         foreach(Instrument.INSTRUMENT_TAG instrument in instrumentsOrder)
@@ -86,6 +78,7 @@ public class InstrumentPositionTaskLocManager : MonoBehaviour
             }
             ++i;
         }
+        */
     }
 
     // Start is called before the first frame update

--- a/VirtualTools/Assets/Scripts/Managers/InstrumentPositionTaskLocManager.cs
+++ b/VirtualTools/Assets/Scripts/Managers/InstrumentPositionTaskLocManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Assertions;
@@ -33,10 +34,9 @@ public class InstrumentPositionTaskLocManager : MonoBehaviour
     }
 
     /// <summary>
-    /// Gameobjects representing locations where instruments can go.
+    /// Gameobjects representing slots where instruments can be placed.
     /// </summary>
-    [SerializeField]
-    List<GameObject> InstrumentLocationSlots;
+    public List<InstrumentPositionTaskSlot> InstrumentSlots { get; set; }
 
     /// <summary>
     /// Instrument monobehaviours for instrument gameobjects in the scene that will be moved to the correct scene location.
@@ -80,9 +80,8 @@ public class InstrumentPositionTaskLocManager : MonoBehaviour
                 List<Instrument> taggedGameObjects = InstrumentGameObjects.FindAll(a => a.instrumentTag == instrument);
             	Assert.AreEqual(taggedGameObjects.Count, 1, "Duplicate INSTRUMENT_TAG in the InstrumentGameObjects");
                 Instrument instrumentToPlace = taggedGameObjects[0];
-                // Place the instrument gameobject in the desired location and unhide it
-                Assert.IsTrue(InstrumentLocationSlots.Count > i);
-                Instantiate<GameObject>(instrumentToPlace.gameObject, InstrumentLocationSlots[i].transform);
+                Assert.IsTrue(InstrumentSlots.Count > i);
+                Instantiate<GameObject>(instrumentToPlace.gameObject, InstrumentSlots[i].transform);
                 instrumentToPlace.gameObject.transform.localPosition = new Vector3();
             }
             ++i;

--- a/VirtualTools/Assets/Scripts/Managers/InstrumentPositionTaskLocManager.cs.meta
+++ b/VirtualTools/Assets/Scripts/Managers/InstrumentPositionTaskLocManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 60d13bc78235f4840a771135c8e7bae1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VirtualTools/Assets/Scripts/Managers/SessionManager.cs
+++ b/VirtualTools/Assets/Scripts/Managers/SessionManager.cs
@@ -42,6 +42,30 @@ public class SessionManager
         return m_currentSession;
     }
 
+    private Session SelectInstrumentPositionSession()
+    {
+        //Will create a session manager
+        Session session = new Session(GenerateID());
+        List<InstrumentPositionTask> allTasks = new List<InstrumentPositionTask>();
+
+        foreach (var tag in InstrumentLocManager.CurrentInstrumentOrder)
+        {
+            if (tag != Instrument.INSTRUMENT_TAG.NONE)
+            {
+                allTasks.Add(new InstrumentPositionTask(tag));
+            }
+        }
+
+        while (allTasks.Count > 0)
+        {
+            int i = UnityEngine.Random.Range(0, allTasks.Count);
+            session.AddTask(allTasks[i]);
+            allTasks.Remove(allTasks[i]);
+        }
+
+        return session;
+    }
+
     private Session SelectByNameSession()
     {
         //Will create a session manager

--- a/VirtualTools/Assets/Scripts/Managers/SessionManager.cs
+++ b/VirtualTools/Assets/Scripts/Managers/SessionManager.cs
@@ -247,6 +247,7 @@ public class SessionManager : MonoBehaviour
         m_currentSession.sessionResults.isAssessed = GameManager.Instance.IsAssessmentMode();
 
         Player.Instance.FreezePlayer(true);
+        Player.Instance.SelectedInstrumentToPlace = null;
 
         GUIManager.Instance.GetMainCanvas().DogInstructionSequence(new string[] {
             "Hi, I'm your assistant! Left click to dismiss my messages",
@@ -295,13 +296,6 @@ public class SessionManager : MonoBehaviour
         {
             // If current task is to position the instruments, select the chosen instrument.
             InstrumentPositionTask instrumentPositionTask = m_currentSession.GetCurrentTask() as InstrumentPositionTask;
-            if(instrumentPositionTask != null)
-            {
-                instrumentPositionTask.SetSelectedInstrument(instrumentTag);
-                Player.Instance.ResetItemAndPlayerToFree();
-                Player.Instance.FreezePlayer(false);
-                Player.Instance.SetPickingEnabled(true);
-            }
 
             // If current task is to select by name or purpose, evaluate the task outcome.
             if (m_currentSession.GetCurrentTask() is InstrumentSelectByNameTask || 

--- a/VirtualTools/Assets/Scripts/Managers/SessionManager.cs
+++ b/VirtualTools/Assets/Scripts/Managers/SessionManager.cs
@@ -511,9 +511,11 @@ public class SessionManager : MonoBehaviour
     /// <summary>
     /// Evaluate the task, used for InstrumentPositionTask
     /// </summary>
-    public void EvaluateTask()
+    public void EndMenu_ClickYes()
     {
-        // Passes None instrument because we don't use this parameter.
+        Player.Instance.HideEndMenu();
+
+        // Passes None instrument because we don't use this parameter for an InstrumentPositionTask.
         m_currentSession.GetCurrentTask().Evaluate(Instrument.INSTRUMENT_TAG.NONE, m_currentSession);
 
         //If this is reached there are no tasks left (write to report here?)
@@ -524,6 +526,14 @@ public class SessionManager : MonoBehaviour
         GUIManager.Instance.ConfigureCursor(true, CursorLockMode.None);
         DisplayResults(m_currentSession);
         ExportResults(m_currentSession);
+    }
+    
+    /// <summary>
+    /// Used for InstrumentPositionTask
+    /// </summary>
+    public void EndMenu_ClickNo()
+    {
+        Player.Instance.HideEndMenu();
     }
 
 }

--- a/VirtualTools/Assets/Scripts/Managers/SessionManager.cs
+++ b/VirtualTools/Assets/Scripts/Managers/SessionManager.cs
@@ -5,6 +5,7 @@ using System.Runtime.Serialization.Formatters.Binary;
 using UnityEngine;
 using System.Threading;
 using System;
+using System.Linq;
 
 public class SessionManager
 {
@@ -74,7 +75,7 @@ public class SessionManager
         Session session = new Session(GenerateID());
         //Randomize? From external file?
         List<InstrumentSelectByNameTask> allTasks = new List<InstrumentSelectByNameTask>();
-        foreach (var tag in InstrumentLocManager.CurrentInstrumentOrder.Distinct<Instrument.INSTRUMENT_TAG>())
+        foreach (var tag in InstrumentLocManager.CurrentInstrumentOrder.Distinct())
         {
             if (tag != Instrument.INSTRUMENT_TAG.NONE)
             {
@@ -99,7 +100,7 @@ public class SessionManager
         //Randomize? From external file?
         List<InstrumentSelectByPurpose> allTasks = new List<InstrumentSelectByPurpose>();
 
-        foreach (var tag in InstrumentLocManager.CurrentInstrumentOrder.Distinct<Instrument.INSTRUMENT_TAG>())
+        foreach (var tag in InstrumentLocManager.CurrentInstrumentOrder.Distinct())
         {
             if (tag != Instrument.INSTRUMENT_TAG.NONE)
             {

--- a/VirtualTools/Assets/Scripts/Managers/SessionManager.cs
+++ b/VirtualTools/Assets/Scripts/Managers/SessionManager.cs
@@ -12,8 +12,6 @@ public class SessionManager : MonoBehaviour
     private static SessionManager m_instance;
     private List<Session> m_sessionsRun;
     private Session m_currentSession;
-    [SerializeField]
-    //private List<GameObject> m_instrumentPositionSlots;
 
     public static SessionManager Instance
     {

--- a/VirtualTools/Assets/Scripts/Managers/SessionManager.cs
+++ b/VirtualTools/Assets/Scripts/Managers/SessionManager.cs
@@ -11,6 +11,8 @@ public class SessionManager
     private static SessionManager m_instance;
     private List<Session> m_sessionsRun;
     private Session m_currentSession;
+    [SerializeField]
+    private List<GameObject> m_instrumentPositionSlots;
 
     public static SessionManager Instance
     {
@@ -52,7 +54,7 @@ public class SessionManager
         {
             if (tag != Instrument.INSTRUMENT_TAG.NONE)
             {
-                allTasks.Add(new InstrumentPositionTask(tag));
+                allTasks.Add(new InstrumentPositionTask("Spay procedure", tag));
             }
         }
 
@@ -154,6 +156,18 @@ public class SessionManager
         return idLong;
     }
 
+    /// <summary>
+    /// Called when the student confirms they've finished positioning instruments for an
+    /// InstrumentPositionTask
+    /// </summary>
+    private void OnConfirmInstrumentPositions()
+    {
+    }
+
+    /// <summary>
+    /// Only for SelectByName or SelectByPurpose Task
+    /// </summary>
+    /// <param name="instrumentTag"></param>
     private void OnInstrumentSelected(Instrument.INSTRUMENT_TAG instrumentTag)
     {
         if(m_currentSession != null)

--- a/VirtualTools/Assets/Scripts/Managers/SessionManager.cs
+++ b/VirtualTools/Assets/Scripts/Managers/SessionManager.cs
@@ -72,8 +72,7 @@ public class SessionManager
         Session session = new Session(GenerateID());
         //Randomize? From external file?
         List<InstrumentSelectByNameTask> allTasks = new List<InstrumentSelectByNameTask>();
-
-        foreach(var tag in InstrumentLocManager.CurrentInstrumentOrder)
+        foreach (var tag in InstrumentLocManager.CurrentInstrumentOrder.Select(x => x).Distinct())
         {
             if (tag != Instrument.INSTRUMENT_TAG.NONE)
             {
@@ -98,7 +97,7 @@ public class SessionManager
         //Randomize? From external file?
         List<InstrumentSelectByPurpose> allTasks = new List<InstrumentSelectByPurpose>();
 
-        foreach (var tag in InstrumentLocManager.CurrentInstrumentOrder)
+        foreach (var tag in InstrumentLocManager.CurrentInstrumentOrder.Select(x => x).Distinct())
         {
             if (tag != Instrument.INSTRUMENT_TAG.NONE)
             {

--- a/VirtualTools/Assets/Scripts/Player/InstrumentSelector.cs
+++ b/VirtualTools/Assets/Scripts/Player/InstrumentSelector.cs
@@ -24,7 +24,7 @@ public class InstrumentSelector
         m_raycastingCamera = camera;
     }
 
-    public Instrument RaycastFromCamera(float raycastLength)
+    public Instrument GetInstrumentRaycastFromCamera(float raycastLength)
     {
         Instrument toReturn = null;
         if(m_raycastingCamera != null)
@@ -39,6 +39,25 @@ public class InstrumentSelector
                 // If an object on layer Instrument was hit, it must be inheriting "IInstrumentSelectable"
                 Instrument instrument = objectHit.gameObject.GetComponent<Instrument>();
                 toReturn = instrument;   
+            }
+        }
+        return toReturn;
+    }
+
+    public InstrumentPositionTaskSlot GetInstrumentPositionTaskSlotRaycastFromCamera(float raycastLength)
+    {
+        InstrumentPositionTaskSlot toReturn = null;
+        if (m_raycastingCamera != null)
+        {
+            RaycastHit hit;
+            Ray ray = new Ray(m_raycastingCamera.transform.position, m_raycastingCamera.transform.forward);
+
+            if (Physics.Raycast(ray, out hit, raycastLength, m_layerMask))
+            {
+                Transform objectHit = hit.transform;
+
+                InstrumentPositionTaskSlot instrument = objectHit.gameObject.GetComponent<InstrumentPositionTaskSlot>();
+                toReturn = instrument;
             }
         }
         return toReturn;

--- a/VirtualTools/Assets/Scripts/Player/Player.cs
+++ b/VirtualTools/Assets/Scripts/Player/Player.cs
@@ -137,8 +137,7 @@ public class Player : MonoBehaviour
     {
         if (Input.GetAxis("Cancel") == 1)
         {
-            Player.Instance.FreezePlayer(true);
-            GUIManager.Instance.ConfigureCursor(true, CursorLockMode.None);
+            GameManager.Instance.Quit();
         }
 
         // TODO needs change for controller support!!!

--- a/VirtualTools/Assets/Scripts/Sessions&Task/InstrumentPositionTask.cs
+++ b/VirtualTools/Assets/Scripts/Sessions&Task/InstrumentPositionTask.cs
@@ -44,10 +44,4 @@ public class InstrumentPositionTask : Task
         return taskStatus;
     }
 
-    internal void SetSelectedInstrument(Instrument.INSTRUMENT_TAG instrumentTag)
-    {
-        Player.Instance.SelectedInstrumentToPlace = instrumentTag;
-        Debug.Log("Selected instrument " + Instrument.GetName(instrumentTag));
-
-    }
 }

--- a/VirtualTools/Assets/Scripts/Sessions&Task/InstrumentPositionTask.cs
+++ b/VirtualTools/Assets/Scripts/Sessions&Task/InstrumentPositionTask.cs
@@ -1,51 +1,53 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
 public class InstrumentPositionTask : Task
 {
-    /// <summary>
-    /// Gameobject representing position where instrument should be placed for this task.
-    /// </summary>
-    GameObject m_correctInstrumentPositionSlot;
-
-    /// <summary>
-    /// The correct instrument to go in that position
-    /// </summary>
-    Instrument.INSTRUMENT_TAG m_correctInstrument;
+    Instrument.INSTRUMENT_TAG m_selectedInstrument;
 
     /// <summary>
     /// 
     /// </summary>
     /// <param name="procedureName">name of the procedure this task is for</param>
     /// <param name="tag"></param>
-    public InstrumentPositionTask(string procedureName, Instrument.INSTRUMENT_TAG tag)
+    public InstrumentPositionTask(string procedureName)
     {
-        m_correctInstrumentPositionSlot = InstrumentPositionTaskLocManager.GetSlotForInstrument(tag);
         instructions.Add("New task: position the instruments for a <b><u>" + procedureName + "</u></b>");
     }
 
     public override STATUS Evaluate(Instrument.INSTRUMENT_TAG instrumentTag, Session session)
     {
-        var instrumentInSlot = m_correctInstrumentPositionSlot.GetComponentInChildren<Instrument>();
-        if(instrumentInSlot == null)
+        taskStatus = STATUS.COMPLETED_SUCCESS;
+
+        foreach (var instrumentSlot in InstrumentPositionTaskLocManager.Instance.InstrumentSlots)
         {
-            session.sessionResults.Log_FailedToPositionInstrument(m_correctInstrument, Instrument.INSTRUMENT_TAG.NONE);
-            taskStatus = STATUS.COMPLETED_FAIL;
-        }
-        else
-        {
-            if (instrumentInSlot.instrumentTag != m_correctInstrument)
+            if (instrumentSlot.CurrentInstrument == Instrument.INSTRUMENT_TAG.NONE)
             {
-                session.sessionResults.Log_FailedToPositionInstrument(m_correctInstrument, instrumentInSlot.instrumentTag);
+                session.sessionResults.Log_FailedToPositionInstrument(instrumentSlot.CorrectInstrument, Instrument.INSTRUMENT_TAG.NONE);
                 taskStatus = STATUS.COMPLETED_FAIL;
             }
             else
             {
-                taskStatus = STATUS.COMPLETED_SUCCESS;
-                session.sessionResults.Log_CorrectlyPositionedInstrument(m_correctInstrument);
+                if (instrumentSlot.CurrentInstrument != instrumentSlot.CorrectInstrument)
+                {
+                    session.sessionResults.Log_FailedToPositionInstrument(instrumentSlot.CorrectInstrument, instrumentSlot.CurrentInstrument);
+                    taskStatus = STATUS.COMPLETED_FAIL;
+                }
+                else
+                {
+                    session.sessionResults.Log_CorrectlyPositionedInstrument(instrumentSlot.CorrectInstrument);
+                }
             }
         }
+
+
         return taskStatus;
+    }
+
+    internal void SetSelectedInstrument(Instrument.INSTRUMENT_TAG instrumentTag)
+    {
+        throw new NotImplementedException();
     }
 }

--- a/VirtualTools/Assets/Scripts/Sessions&Task/InstrumentPositionTask.cs
+++ b/VirtualTools/Assets/Scripts/Sessions&Task/InstrumentPositionTask.cs
@@ -5,46 +5,42 @@ using UnityEngine;
 public class InstrumentPositionTask : Task
 {
     /// <summary>
-    /// Gameobjects representing locations where instruments can be placed for the task.
+    /// Gameobject representing position where instrument should be placed for this task.
     /// </summary>
-    List<Instrument> InstrumentPositionSlots { get; set; }
-    private string m_procedureName;
-    private List<Instrument.INSTRUMENT_TAG> m_correctInstrumentPositions;
-    public List<Instrument.INSTRUMENT_TAG> ActualInstrumentPositions
-    {
-        get
-        {
-            List<Instrument.INSTRUMENT_TAG> positions = new List<Instrument.INSTRUMENT_TAG>();
-            foreach (var slot in InstrumentPositionSlots)
-            {
-                positions.Add(slot.instrumentTag);
-            }
-            return positions;
-        }
-    }
+    GameObject m_correctInstrumentPositionSlot;
 
-    public InstrumentPositionTask(string procedureName, List<Instrument.INSTRUMENT_TAG> correctInstrumentPositions)
-    {
-        m_procedureName = procedureName;
-        m_correctInstrumentPositions = correctInstrumentPositions;
+    /// <summary>
+    /// The correct instrument to go in that position
+    /// </summary>
+    Instrument.INSTRUMENT_TAG m_correctInstrument;
 
-        instructions.Add("New task: position the instruments for a <b><u>" + "INSERT PROCEDURE NAME HERE" + "</u></b>");
+    public InstrumentPositionTask(string procedureName, GameObject correctInstrumentPositionSlot)
+    {
+        m_correctInstrumentPositionSlot = correctInstrumentPositionSlot;
+        instructions.Add("New task: position the instruments for a <b><u>" + procedureName + "</u></b>");
     }
 
     public override STATUS Evaluate(Instrument.INSTRUMENT_TAG instrumentTag, Session session)
     {
-        if (m_instrumentToSelect == instrumentTag)
+        var instrumentInSlot = m_correctInstrumentPositionSlot.GetComponentInChildren<Instrument>();
+        if(instrumentInSlot == null)
         {
-            taskStatus = STATUS.COMPLETED_SUCCESS;
-            session.sessionResults.Log_CorrectlySelectedInstrumentByName(m_instrumentToSelect);
+            session.sessionResults.Log_FailedToPositionInstrument(m_correctInstrument, Instrument.INSTRUMENT_TAG.NONE);
+            taskStatus = STATUS.COMPLETED_FAIL;
         }
         else
         {
-            session.sessionResults.Log_FailedToSelectByName(m_instrumentToSelect, instrumentTag);
-
-            taskStatus = STATUS.COMPLETED_FAIL;
+            if (instrumentInSlot.instrumentTag != m_correctInstrument)
+            {
+                session.sessionResults.Log_FailedToPositionInstrument(m_correctInstrument, instrumentInSlot.instrumentTag);
+                taskStatus = STATUS.COMPLETED_FAIL;
+            }
+            else
+            {
+                taskStatus = STATUS.COMPLETED_SUCCESS;
+                session.sessionResults.Log_CorrectlyPositionedInstrument(m_correctInstrument);
+            }
         }
-
         return taskStatus;
     }
 }

--- a/VirtualTools/Assets/Scripts/Sessions&Task/InstrumentPositionTask.cs
+++ b/VirtualTools/Assets/Scripts/Sessions&Task/InstrumentPositionTask.cs
@@ -14,9 +14,14 @@ public class InstrumentPositionTask : Task
     /// </summary>
     Instrument.INSTRUMENT_TAG m_correctInstrument;
 
-    public InstrumentPositionTask(string procedureName, GameObject correctInstrumentPositionSlot)
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="procedureName">name of the procedure this task is for</param>
+    /// <param name="tag"></param>
+    public InstrumentPositionTask(string procedureName, Instrument.INSTRUMENT_TAG tag)
     {
-        m_correctInstrumentPositionSlot = correctInstrumentPositionSlot;
+        m_correctInstrumentPositionSlot = InstrumentPositionTaskLocManager.GetSlotForInstrument(tag);
         instructions.Add("New task: position the instruments for a <b><u>" + procedureName + "</u></b>");
     }
 

--- a/VirtualTools/Assets/Scripts/Sessions&Task/InstrumentPositionTask.cs
+++ b/VirtualTools/Assets/Scripts/Sessions&Task/InstrumentPositionTask.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class InstrumentPositionTask : Task
+{
+    /// <summary>
+    /// Gameobjects representing locations where instruments can be placed for the task.
+    /// </summary>
+    List<Instrument> InstrumentPositionSlots { get; set; }
+    private string m_procedureName;
+    private List<Instrument.INSTRUMENT_TAG> m_correctInstrumentPositions;
+    public List<Instrument.INSTRUMENT_TAG> ActualInstrumentPositions
+    {
+        get
+        {
+            List<Instrument.INSTRUMENT_TAG> positions = new List<Instrument.INSTRUMENT_TAG>();
+            foreach (var slot in InstrumentPositionSlots)
+            {
+                positions.Add(slot.instrumentTag);
+            }
+            return positions;
+        }
+    }
+
+    public InstrumentPositionTask(string procedureName, List<Instrument.INSTRUMENT_TAG> correctInstrumentPositions)
+    {
+        m_procedureName = procedureName;
+        m_correctInstrumentPositions = correctInstrumentPositions;
+
+        instructions.Add("New task: position the instruments for a <b><u>" + "INSERT PROCEDURE NAME HERE" + "</u></b>");
+    }
+
+    public override STATUS Evaluate(Instrument.INSTRUMENT_TAG instrumentTag, Session session)
+    {
+        if (m_instrumentToSelect == instrumentTag)
+        {
+            taskStatus = STATUS.COMPLETED_SUCCESS;
+            session.sessionResults.Log_CorrectlySelectedInstrumentByName(m_instrumentToSelect);
+        }
+        else
+        {
+            session.sessionResults.Log_FailedToSelectByName(m_instrumentToSelect, instrumentTag);
+
+            taskStatus = STATUS.COMPLETED_FAIL;
+        }
+
+        return taskStatus;
+    }
+}

--- a/VirtualTools/Assets/Scripts/Sessions&Task/InstrumentPositionTask.cs
+++ b/VirtualTools/Assets/Scripts/Sessions&Task/InstrumentPositionTask.cs
@@ -5,8 +5,6 @@ using UnityEngine;
 
 public class InstrumentPositionTask : Task
 {
-    Instrument.INSTRUMENT_TAG m_selectedInstrument;
-
     /// <summary>
     /// 
     /// </summary>
@@ -48,6 +46,8 @@ public class InstrumentPositionTask : Task
 
     internal void SetSelectedInstrument(Instrument.INSTRUMENT_TAG instrumentTag)
     {
-        throw new NotImplementedException();
+        Player.Instance.SelectedInstrumentToPlace = instrumentTag;
+        Debug.Log("Selected instrument " + Instrument.GetName(instrumentTag));
+
     }
 }

--- a/VirtualTools/Assets/Scripts/Sessions&Task/InstrumentPositionTask.cs.meta
+++ b/VirtualTools/Assets/Scripts/Sessions&Task/InstrumentPositionTask.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 39a8800486e14024a8d394b5d55796c1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VirtualTools/Assets/Scripts/Sessions&Task/Session.cs
+++ b/VirtualTools/Assets/Scripts/Sessions&Task/Session.cs
@@ -40,9 +40,19 @@ public class SessionResults
         logs.Add(DateTime.Now.ToShortTimeString() + " - Failed to select by name " + Instrument.GetName(toSelectinstrumentTag) + ". Selected: " + Instrument.GetName(selectedInstrumentTag));
     }
 
+    internal void Log_FailedToPositionInstrument(Instrument.INSTRUMENT_TAG correctInstrumentTag, Instrument.INSTRUMENT_TAG actualInstrumentTag)
+    {
+        logs.Add(DateTime.Now.ToShortTimeString() + " - Incorrectly placed " + Instrument.GetName(actualInstrumentTag) + " where the " + Instrument.GetName(correctInstrumentTag) + " should have gone.");
+    }
+
     public void Log_FailedToSelectByPurpose(Instrument.INSTRUMENT_TAG toSelectinstrumentTag, Instrument.INSTRUMENT_TAG selectedInstrumentTag)
     {
         logs.Add(DateTime.Now.ToShortTimeString() + " - Failed to select by purpose " + Instrument.GetName(toSelectinstrumentTag) + ". Selected: " + Instrument.GetName(selectedInstrumentTag));
+    }
+
+    internal void Log_CorrectlyPositionedInstrument(Instrument.INSTRUMENT_TAG instrumentTag)
+    {
+        logs.Add(DateTime.Now.ToShortTimeString() + " - Correctly placed " + Instrument.GetName(instrumentTag));
     }
 
     public void Log_CorrectlySelectedInstrumentByPurpose(Instrument.INSTRUMENT_TAG instrumentTag)

--- a/VirtualTools/Assets/Standard Assets/Characters/FirstPersonCharacter/Scripts/FirstPersonController.cs
+++ b/VirtualTools/Assets/Standard Assets/Characters/FirstPersonCharacter/Scripts/FirstPersonController.cs
@@ -42,6 +42,22 @@ namespace UnityStandardAssets.Characters.FirstPerson
         private bool m_Jumping;
         private AudioSource m_AudioSource;
 
+        public bool AllowMouseLook = true;
+
+        private static FirstPersonController m_instance;
+        public static FirstPersonController Instance
+        {
+            get
+            {
+                if (m_instance == null)
+                {
+                    m_instance = FindObjectOfType<FirstPersonController>();
+                }
+
+                return m_instance;
+            }
+        }
+
         // Use this for initialization
         private void Start()
         {
@@ -204,7 +220,6 @@ namespace UnityStandardAssets.Characters.FirstPerson
             // Read input
             float horizontal = CrossPlatformInputManager.GetAxis("Horizontal");
             float vertical = CrossPlatformInputManager.GetAxis("Vertical");
-
             bool waswalking = m_IsWalking;
 
 #if !MOBILE_INPUT


### PR DESCRIPTION
Adds functionality for a third session type - positioning instruments. This can be selected in the menu at the start (in practice mode).
Press enter to confirm the position of instruments and end the session.

Limitations
- If not all the instruments are in the scene, it will not be possible to pass. I'm not sure how we should address this.
- Does not correctly show results in report at the end, it just says it passes.
- Next it needs to allow re-ordering instruments after placing
- You can pick up an instrument before you finish clicking through prompts and it doesn't follow the player properly
- Some of the instruments are still rotated inconsistently but they're not fully sideways any more
- Ending the session needs controller support and there should be a UI prompt telling you how to end the session
- Camera should freeze before they finish clicking through the prompts at the start of the session, as they shouldnt be able to pick up an instrument until dismissed prompts
